### PR TITLE
Show unsupported QR code popup (PIA-1615)

### DIFF
--- a/ginicapture/src/androidTest/java/net/gini/android/capture/camera/CameraScreenTest.java
+++ b/ginicapture/src/androidTest/java/net/gini/android/capture/camera/CameraScreenTest.java
@@ -49,6 +49,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -579,7 +580,8 @@ public class CameraScreenTest {
                 cameraActivityFake.getCameraFragmentImplFake();
         Thread.sleep(CameraFragmentImpl.DEFAULT_ANIMATION_DURATION + 100);
         Mockito.verify(cameraFragmentImplFake, times(2))
-                .showQRCodeDetectedPopup(anyLong());
+                .mPaymentQRCodePopup.show(ArgumentMatchers.<PaymentQRCodeData>any(),
+                anyLong());
     }
 
     @Test

--- a/ginicapture/src/doc/source/customization-guide.rst
+++ b/ginicapture/src/doc/source/customization-guide.rst
@@ -512,31 +512,66 @@ All Action Bar customizations except the title are global to all Activities.
 
 - **Background Color**
 
-  Via the color resource named ``gc_qrcode_detected_popup_background``.
+  - **Payable QRCode**
 
-- **Message**
+    Via the color resource named ``gc_qrcode_detected_popup_background``.
 
-  - **Text**
+  - **Unsupported QRCode**
 
-    Via the string resources named ``gc_qrcode_detected_popup_message_1`` and
-    ``gc_qrcode_detected_popup_message_2``.
+    Via the color resource named ``gc_unsupported_qrcode_detected_popup_background``.
 
-  - **Text Style**
+ - **Message**
 
-    Via overriding the styles named
-    ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle`` (with parent style
-    ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle``) and
-    ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle`` (with parent style
-    ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle``).
+   - **Text**
 
-  - **Font**
+    - **Payable QRCode**
 
-    Via overriding the styles named
-    ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle`` (with parent style
-    ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle``) and
-    ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle`` (with parent style
-    ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle``). and setting an
-    item named ``gcCustomFont`` with the path to the font file in your assets folder.
+      Via the string resources named ``gc_qrcode_detected_popup_message_1`` and
+      ``gc_qrcode_detected_popup_message_2``.
+
+    - **Unsupported QRCode**
+
+      Via the string resources named ``gc_unsupported_qrcode_detected_popup_message_1`` and
+      ``gc_unsupported_qrcode_detected_popup_message_2``.
+
+   - **Text Style**
+
+    - **Payable QRCode**
+
+      Via overriding the styles named
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle``) and
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle``).
+
+    - **Unsupported QRCode**
+
+      Via overriding the styles named
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle``) and
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle``).
+
+
+   - **Font**
+
+    - **Payable QRCode**
+
+      Via overriding the styles named
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle``) and
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle``). and setting an
+      item named ``gvCustomFont`` with the path to the font file in your assets folder.
+
+    - **Unsupported QRCode**
+
+      Via overriding the styles named
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle``) and
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle``). and setting an
+      item named ``gvCustomFont`` with the path to the font file in your assets folder.
 
 :ref:`Back to screenshots. <camera>`
 

--- a/ginicapture/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
+++ b/ginicapture/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
@@ -1,0 +1,116 @@
+package net.gini.android.capture.internal.camera.view
+
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.ViewPropertyAnimatorCompat
+import androidx.core.view.ViewPropertyAnimatorListener
+import androidx.core.view.ViewPropertyAnimatorListenerAdapter
+import net.gini.android.capture.internal.ui.FragmentImplCallback
+
+/**
+ * Internal use only.
+ *
+ * @suppress
+ */
+internal class QRCodePopup<T> @JvmOverloads constructor(
+        private val fragmentImplCallback: FragmentImplCallback,
+        private val popupView: View,
+        private val animationDuration: Long,
+        private val hideDelayMs: Long,
+        private val showAgainDelayMs: Long,
+        private val onClicked: (T?) -> Unit = {}) {
+
+    private var animation: ViewPropertyAnimatorCompat? = null
+    private val hideRunnable: Runnable = Runnable {
+        hide()
+    }
+
+    var qrCodeContent: T? = null
+        private set
+
+    var isShown = false
+        private set
+
+    init {
+        popupView.setOnClickListener {
+            onClicked(qrCodeContent)
+            hide()
+        }
+    }
+
+    @JvmOverloads
+    fun show(qrCodeContent: T, startDelay: Long = 0) {
+        if (this.qrCodeContent != null && qrCodeContent != this.qrCodeContent) {
+            hide(object : ViewPropertyAnimatorListenerAdapter() {
+                override fun onAnimationEnd(view: View?) {
+                    show(showAgainDelayMs)
+                }
+            })
+        } else {
+            show(startDelay)
+        }
+
+        this.qrCodeContent = qrCodeContent
+    }
+
+    private fun show(startDelay: Long = 0) {
+        if (popupView.alpha != 0f) {
+            fragmentImplCallback.view?.removeCallbacks(hideRunnable)
+            fragmentImplCallback.view?.postDelayed(hideRunnable, hideDelayMs)
+            return
+        }
+
+        clearQRCodeDetectedPopUpAnimation()
+        popupView.visibility = View.VISIBLE
+        animation = ViewCompat.animate(popupView)
+                .alpha(1.0f)
+                .setStartDelay(startDelay)
+                .setDuration(animationDuration)
+                .setListener(object : ViewPropertyAnimatorListenerAdapter() {
+                    override fun onAnimationEnd(view: View?) {
+                        isShown = true
+                    }
+                })
+                .apply {
+                    start()
+                }
+
+        fragmentImplCallback.view?.removeCallbacks(hideRunnable)
+        fragmentImplCallback.view?.postDelayed(hideRunnable, hideDelayMs)
+    }
+
+    @JvmOverloads
+    fun hide(animatorListener: ViewPropertyAnimatorListener? = null) {
+        qrCodeContent = null
+
+        if (popupView.alpha != 1f) {
+            animatorListener?.onAnimationEnd(popupView)
+            return
+        }
+        clearQRCodeDetectedPopUpAnimation()
+        animation = ViewCompat.animate(popupView)
+                .alpha(0.0f)
+                .setDuration(animationDuration)
+                .setListener(object : ViewPropertyAnimatorListenerAdapter() {
+                    override fun onAnimationEnd(view: View) {
+                        popupView.visibility = View.GONE
+                        isShown = false
+                        animatorListener?.onAnimationEnd(view)
+                    }
+                })
+                .apply {
+                    start()
+                }
+
+        fragmentImplCallback.view?.removeCallbacks(hideRunnable)
+    }
+
+    private fun clearQRCodeDetectedPopUpAnimation() {
+        animation?.apply {
+            cancel()
+            popupView.clearAnimation()
+            setListener(null)
+        }
+        fragmentImplCallback.view?.removeCallbacks(hideRunnable)
+    }
+}

--- a/ginicapture/src/main/java/net/gini/android/capture/internal/qrcode/PaymentQRCodeReader.java
+++ b/ginicapture/src/main/java/net/gini/android/capture/internal/qrcode/PaymentQRCodeReader.java
@@ -32,6 +32,10 @@ public class PaymentQRCodeReader {
         public void onPaymentQRCodeDataAvailable(
                 @NonNull final PaymentQRCodeData paymentQRCodeData) {
         }
+
+        @Override
+        public void onNonPaymentQRCodeDetected(@NonNull final String qrCodeContent) {
+        }
     };
 
     /**
@@ -62,6 +66,7 @@ public class PaymentQRCodeReader {
                         mListener.onPaymentQRCodeDataAvailable(paymentData);
                         return;
                     } catch (final IllegalArgumentException ignored) {
+                        mListener.onNonPaymentQRCodeDetected(qrCodeContent);
                     }
                 }
             }
@@ -109,5 +114,12 @@ public class PaymentQRCodeReader {
          * @param paymentQRCodeData the payment data found on the image
          */
         void onPaymentQRCodeDataAvailable(@NonNull final PaymentQRCodeData paymentQRCodeData);
+
+        /**
+         * Called when a QRCode was found without a supported payment data format.
+         *
+         * @param qrCodeContent the content of the QRCode
+         */
+        void onNonPaymentQRCodeDetected(@NonNull final String qrCodeContent);
     }
 }

--- a/ginicapture/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
+++ b/ginicapture/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
@@ -148,6 +148,57 @@
 
     </RelativeLayout>
 
+    <RelativeLayout
+        android:id="@+id/gc_unsupported_qrcode_detected_popup_container"
+        android:layout_width="@dimen/gc_camera_qrcode_detected_popup_width"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="@dimen/gc_camera_qrcode_detected_popup_vertical_margin"
+        android:alpha="0"
+        android:background="@color/gc_unsupported_qrcode_detected_popup_background"
+        android:paddingBottom="@dimen/gc_camera_qrcode_detected_popup_vertical_padding"
+        android:paddingLeft="@dimen/gc_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingRight="@dimen/gc_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingTop="@dimen/gc_camera_qrcode_detected_popup_vertical_padding"
+        android:visibility="gone"
+        tools:alpha="1"
+        tools:visibility="visible">
+
+        <ImageView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_icon"
+            android:layout_width="@dimen/gc_camera_qrcode_icon_size"
+            android:layout_height="@dimen/gc_camera_qrcode_icon_size"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:src="@drawable/qr_code_icon"
+            tools:ignore="ContentDescription" />
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_1"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginLeft="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginRight="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginStart="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_toEndOf="@id/gc_camera_unsupported_qrcode_detected_popup_icon"
+            android:layout_toStartOf="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
+            android:text="@string/gc_unsupported_qrcode_detected_popup_message_1" />
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:text="@string/gc_unsupported_qrcode_detected_popup_message_2" />
+
+    </RelativeLayout>
+
     <View
         android:id="@+id/gc_image_stack_placeholder"
         android:layout_width="wrap_content"
@@ -169,7 +220,7 @@
         android:layout_alignEnd="@id/gc_image_stack_placeholder"
         android:layout_marginStart="@dimen/gc_camera_image_stack_left_margin"
         android:layout_marginTop="@dimen/gc_camera_image_stack_top_margin"
-        tools:visibility="visible" />
+        tools:visibility="gone" />
 
     <LinearLayout
         android:id="@+id/gc_document_import_button_container"

--- a/ginicapture/src/main/res/layout-sw600dp/gc_fragment_camera.xml
+++ b/ginicapture/src/main/res/layout-sw600dp/gc_fragment_camera.xml
@@ -189,6 +189,57 @@
 
     </RelativeLayout>
 
+    <RelativeLayout
+        android:id="@+id/gc_unsupported_qrcode_detected_popup_container"
+        android:layout_width="@dimen/gc_camera_qrcode_detected_popup_width"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/gc_button_camera_trigger"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="@dimen/gc_camera_qrcode_detected_popup_vertical_margin"
+        android:alpha="0"
+        android:background="@color/gc_unsupported_qrcode_detected_popup_background"
+        android:paddingBottom="@dimen/gc_camera_qrcode_detected_popup_vertical_padding"
+        android:paddingLeft="@dimen/gc_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingRight="@dimen/gc_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingTop="@dimen/gc_camera_qrcode_detected_popup_vertical_padding"
+        android:visibility="gone"
+        tools:alpha="1"
+        tools:visibility="invisible">
+
+        <ImageView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_icon"
+            android:layout_width="@dimen/gc_camera_qrcode_icon_size"
+            android:layout_height="@dimen/gc_camera_qrcode_icon_size"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:src="@drawable/qr_code_icon"
+            tools:ignore="ContentDescription" />
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_1"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginLeft="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginRight="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginStart="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_toEndOf="@id/gc_camera_unsupported_qrcode_detected_popup_icon"
+            android:layout_toStartOf="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
+            android:text="@string/gc_unsupported_qrcode_detected_popup_message_1" />
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:text="@string/gc_unsupported_qrcode_detected_popup_message_2" />
+
+    </RelativeLayout>
+
     <View
         android:id="@+id/gc_image_stack_placeholder"
         android:layout_width="60dp"
@@ -209,7 +260,7 @@
         android:layout_alignEnd="@id/gc_image_stack_placeholder"
         android:layout_marginStart="@dimen/gc_camera_image_stack_left_margin"
         android:layout_marginTop="@dimen/gc_camera_image_stack_top_margin"
-        tools:visibility="visible" />
+        tools:visibility="gone" />
 
     <LinearLayout
         android:id="@+id/gc_document_import_button_container"

--- a/ginicapture/src/main/res/layout/gc_fragment_camera.xml
+++ b/ginicapture/src/main/res/layout/gc_fragment_camera.xml
@@ -1,5 +1,6 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/gc_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -103,7 +104,7 @@
         android:layout_alignStart="@+id/gc_document_import_button_container"
         android:alpha="0"
         android:src="@drawable/gc_hint_arrow_down"
-        android:tint="@color/gc_document_import_hint_background"
+        app:tint="@color/gc_document_import_hint_background"
         android:visibility="gone"
         tools:alpha="1"
         tools:visibility="visible" />
@@ -143,7 +144,7 @@
             android:layout_centerVertical="true"
             android:padding="@dimen/gc_camera_upload_hint_container_close_button_padding"
             android:src="@drawable/gc_hint_close"
-            android:tint="@color/gc_hint_close" />
+            app:tint="@color/gc_hint_close" />
 
     </RelativeLayout>
 
@@ -193,6 +194,56 @@
             android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
             android:text="@string/gc_qrcode_detected_popup_message_2" />
+
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/gc_unsupported_qrcode_detected_popup_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/gc_button_camera_trigger"
+        android:layout_marginBottom="@dimen/gc_camera_qrcode_detected_popup_vertical_margin"
+        android:layout_marginLeft="@dimen/gc_camera_qrcode_detected_popup_horizontal_margin"
+        android:layout_marginRight="@dimen/gc_camera_qrcode_detected_popup_horizontal_margin"
+        android:alpha="0"
+        android:background="@color/gc_unsupported_qrcode_detected_popup_background"
+        android:paddingBottom="@dimen/gc_camera_qrcode_detected_popup_vertical_padding"
+        android:paddingLeft="@dimen/gc_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingRight="@dimen/gc_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingTop="@dimen/gc_camera_qrcode_detected_popup_vertical_padding"
+        android:visibility="gone">
+
+        <ImageView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_icon"
+            android:layout_width="@dimen/gc_camera_qrcode_icon_size"
+            android:layout_height="@dimen/gc_camera_qrcode_icon_size"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:src="@drawable/qr_code_icon"
+            tools:ignore="ContentDescription" />
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_1"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginLeft="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginRight="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginStart="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_toEndOf="@id/gc_camera_unsupported_qrcode_detected_popup_icon"
+            android:layout_toStartOf="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
+            android:text="@string/gc_unsupported_qrcode_detected_popup_message_1" />
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:text="@string/gc_unsupported_qrcode_detected_popup_message_2" />
 
     </RelativeLayout>
 

--- a/ginicapture/src/main/res/values-en/strings.xml
+++ b/ginicapture/src/main/res/values-en/strings.xml
@@ -17,6 +17,8 @@
     <string name="gc_document_error_multi_page_limit_cancel_button">Cancel</string>
     <string name="gc_qrcode_detected_popup_message_1">Use QR code?</string>
     <string name="gc_qrcode_detected_popup_message_2">Continue</string>
+    <string name="gc_unsupported_qrcode_detected_popup_message_1">This QR Code does not contain any payment information.</string>
+    <string name="gc_unsupported_qrcode_detected_popup_message_2">X</string>
     <string name="gc_onboarding_lighting">Ensure good lighting when photographing the invoice or remittance slip</string>
     <string name="gc_onboarding_flat">Flatten the page</string>
     <string name="gc_onboarding_parallel">Hold device parallel over the page</string>

--- a/ginicapture/src/main/res/values/colors.xml
+++ b/ginicapture/src/main/res/values/colors.xml
@@ -27,6 +27,10 @@
     <color name="gc_qrcode_detected_popup_message_1">#000</color>
     <color name="gc_qrcode_detected_popup_message_2">#009edc</color>
 
+    <color name="gc_unsupported_qrcode_detected_popup_background">#eeffffff</color>
+    <color name="gc_unsupported_qrcode_detected_popup_message_1">#e30b5d</color>
+    <color name="gc_unsupported_qrcode_detected_popup_message_2">#e30b5d</color>
+
     <color name="gc_document_import_hint_background">#ffffff</color>
     <color name="gc_document_import_hint_text">#000000</color>
 

--- a/ginicapture/src/main/res/values/strings.xml
+++ b/ginicapture/src/main/res/values/strings.xml
@@ -18,12 +18,16 @@
     <string name="gc_camera_error_no_permission_button_title">Zugriff erlauben</string>
     <string name="gc_camera_image_stack_subtitle">Seiten</string>
     <string name="gc_camera_document_import_subtitle">Importieren</string>
+
     <string name="gc_document_error_multi_page_limit_review_pages_button">Seitenübersicht</string>
-
     <string name="gc_document_error_multi_page_limit_cancel_button">Abbrechen</string>
-    <string name="gc_qrcode_detected_popup_message_1">QR verwenden?</string>
 
+    <string name="gc_qrcode_detected_popup_message_1">QR verwenden?</string>
     <string name="gc_qrcode_detected_popup_message_2">Hier geht’s weiter.</string>
+
+    <string name="gc_unsupported_qrcode_detected_popup_message_1">Dieser QR-Code enthält keine Bezahlinformationen.</string>
+    <string name="gc_unsupported_qrcode_detected_popup_message_2">X</string>
+
     <string name="gc_onboarding_lighting">Beim Abfotografieren der Rechnung oder des Überweisungsträgers auf gute Beleuchtung achten</string>
     <string name="gc_onboarding_flat">Seite glatt streichen</string>
     <string name="gc_onboarding_parallel">Gerät parallel über die Seite halten</string>

--- a/ginicapture/src/main/res/values/styles.xml
+++ b/ginicapture/src/main/res/values/styles.xml
@@ -71,6 +71,18 @@
         <item name="gcCustomFont" />
     </style>
 
+    <style name="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle" parent="TextAppearance.AppCompat">
+        <item name="android:textSize">14sp</item>
+        <item name="android:textColor">@color/gc_unsupported_qrcode_detected_popup_message_1</item>
+        <item name="gcCustomFont" />
+    </style>
+
+    <style name="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle" parent="TextAppearance.AppCompat">
+        <item name="android:textSize">14sp</item>
+        <item name="android:textColor">@color/gc_unsupported_qrcode_detected_popup_message_2</item>
+        <item name="gcCustomFont" />
+    </style>
+
     <style name="Root.GiniCaptureTheme.Camera.DocumentImportSubtitle.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textSize">12sp</item>
         <item name="android:textColor">@color/gc_camera_document_import_subtitle_text</item>
@@ -253,6 +265,10 @@
     <style name="GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle" parent="Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle" />
 
     <style name="GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle" parent="Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle" />
+
+    <style name="GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle" parent="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle" />
+
+    <style name="GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle" parent="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle" />
 
     <style name="GiniCaptureTheme.Camera.DocumentImportSubtitle.TextStyle" parent="Root.GiniCaptureTheme.Camera.DocumentImportSubtitle.TextStyle" />
 


### PR DESCRIPTION
Ported feature from GVL by applying the following GVL commits:
* f5017e14 Add unsupported QR code popup to tablet layouts
* 9ff507c3 Add unsupported QR code popup to customization guide
* e5946b57 Fix failing test
* 9697a3f7 Show unsupported QR code popup
* a0d37044 Add listener method to detect non-payment QR codes
* 96a38f53 Extract QR code popup related logic into a dedicated class