### PR TITLE
Show QR code hint and show QR code as a supported format in help (PIA-1617)

### DIFF
--- a/ginicapture/src/androidTest/java/net/gini/android/capture/camera/CameraScreenTest.java
+++ b/ginicapture/src/androidTest/java/net/gini/android/capture/camera/CameraScreenTest.java
@@ -49,6 +49,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -579,7 +580,8 @@ public class CameraScreenTest {
                 cameraActivityFake.getCameraFragmentImplFake();
         Thread.sleep(CameraFragmentImpl.DEFAULT_ANIMATION_DURATION + 100);
         Mockito.verify(cameraFragmentImplFake, times(2))
-                .showQRCodeDetectedPopup(anyLong());
+                .mPaymentQRCodePopup.show(ArgumentMatchers.<PaymentQRCodeData>any(),
+                anyLong());
     }
 
     @Test

--- a/ginicapture/src/doc/source/customization-guide.rst
+++ b/ginicapture/src/doc/source/customization-guide.rst
@@ -512,31 +512,66 @@ All Action Bar customizations except the title are global to all Activities.
 
 - **Background Color**
 
-  Via the color resource named ``gc_qrcode_detected_popup_background``.
+  - **Payable QRCode**
 
-- **Message**
+    Via the color resource named ``gc_qrcode_detected_popup_background``.
 
-  - **Text**
+  - **Unsupported QRCode**
 
-    Via the string resources named ``gc_qrcode_detected_popup_message_1`` and
-    ``gc_qrcode_detected_popup_message_2``.
+    Via the color resource named ``gc_unsupported_qrcode_detected_popup_background``.
 
-  - **Text Style**
+ - **Message**
 
-    Via overriding the styles named
-    ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle`` (with parent style
-    ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle``) and
-    ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle`` (with parent style
-    ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle``).
+   - **Text**
 
-  - **Font**
+    - **Payable QRCode**
 
-    Via overriding the styles named
-    ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle`` (with parent style
-    ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle``) and
-    ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle`` (with parent style
-    ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle``). and setting an
-    item named ``gcCustomFont`` with the path to the font file in your assets folder.
+      Via the string resources named ``gc_qrcode_detected_popup_message_1`` and
+      ``gc_qrcode_detected_popup_message_2``.
+
+    - **Unsupported QRCode**
+
+      Via the string resources named ``gc_unsupported_qrcode_detected_popup_message_1`` and
+      ``gc_unsupported_qrcode_detected_popup_message_2``.
+
+   - **Text Style**
+
+    - **Payable QRCode**
+
+      Via overriding the styles named
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle``) and
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle``).
+
+    - **Unsupported QRCode**
+
+      Via overriding the styles named
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle``) and
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle``).
+
+
+   - **Font**
+
+    - **Payable QRCode**
+
+      Via overriding the styles named
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle``) and
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle``). and setting an
+      item named ``gvCustomFont`` with the path to the font file in your assets folder.
+
+    - **Unsupported QRCode**
+
+      Via overriding the styles named
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle``) and
+      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle`` (with parent style
+      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle``). and setting an
+      item named ``gvCustomFont`` with the path to the font file in your assets folder.
 
 :ref:`Back to screenshots. <camera>`
 

--- a/ginicapture/src/doc/source/customization-guide.rst
+++ b/ginicapture/src/doc/source/customization-guide.rst
@@ -429,8 +429,11 @@ All Action Bar customizations except the title are global to all Activities.
 
 .. _camera-8:
 
-8. Document Import Hint
+8. Hints
 ^^^^
+
+8.1 Document Import Hint
+~~~~
 
 - **Background Color**
 
@@ -456,6 +459,35 @@ All Action Bar customizations except the title are global to all Activities.
     Via overriding the style named ``GiniCaptureTheme.Camera.DocumentImportHint.TextStyle`` (with
     parent style ``Root.GiniCaptureTheme.Camera.DocumentImportHint.TextStyle``) and setting an
     item named ``gcCustomFont`` with the path to the font file in your assets folder.
+
+8.2 QR Code Scanner Hint
+~~~~
+
+- **Background Color**
+
+  Via the color resource named ``gc_document_import_hint_background``.
+
+- **Close Icon Color**
+
+  Via the color resource name ``gc_hint_close``.
+
+- **Message**
+
+  - **Text**
+
+    Via the string resource named ``gc_qr_code_scanner_hint_text``.
+
+  - **Text Style**
+
+    Via overriding the style named ``GiniCaptureTheme.Camera.DocumentImportHint.TextStyle`` (with
+    parent style ``Root.GiniCaptureTheme.Camera.DocumentImportHint.TextStyle``).
+
+  - **Font**
+
+    Via overriding the style named ``GiniCaptureTheme.Camera.DocumentImportHint.TextStyle`` (with
+    parent style ``Root.GiniCaptureTheme.Camera.DocumentImportHint.TextStyle``) and setting an
+    item named ``gcCustomFont`` with the path to the font file in your assets folder.
+
 
 :ref:`Back to screenshots. <camera>`
 
@@ -539,18 +571,18 @@ All Action Bar customizations except the title are global to all Activities.
     - **Payable QRCode**
 
       Via overriding the styles named
-      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle`` (with parent style
-      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle``) and
-      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle`` (with parent style
-      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle``).
+      ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle`` (with parent style
+      ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle``) and
+      ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle`` (with parent style
+      ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle``).
 
     - **Unsupported QRCode**
 
       Via overriding the styles named
-      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle`` (with parent style
-      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle``) and
-      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle`` (with parent style
-      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle``).
+      ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle`` (with parent style
+      ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle``) and
+      ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle`` (with parent style
+      ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle``).
 
 
    - **Font**
@@ -558,19 +590,19 @@ All Action Bar customizations except the title are global to all Activities.
     - **Payable QRCode**
 
       Via overriding the styles named
-      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle`` (with parent style
-      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle``) and
-      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle`` (with parent style
-      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle``). and setting an
+      ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle`` (with parent style
+      ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle``) and
+      ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle`` (with parent style
+      ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle``). and setting an
       item named ``gvCustomFont`` with the path to the font file in your assets folder.
 
     - **Unsupported QRCode**
 
       Via overriding the styles named
-      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle`` (with parent style
-      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle``) and
-      ``GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle`` (with parent style
-      ``Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle``). and setting an
+      ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle`` (with parent style
+      ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle``) and
+      ``GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle`` (with parent style
+      ``Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle``). and setting an
       item named ``gvCustomFont`` with the path to the font file in your assets folder.
 
 :ref:`Back to screenshots. <camera>`

--- a/ginicapture/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/ginicapture/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -56,6 +56,7 @@ import net.gini.android.capture.internal.camera.photo.Photo;
 import net.gini.android.capture.internal.camera.photo.PhotoEdit;
 import net.gini.android.capture.internal.camera.view.CameraPreviewSurface;
 import net.gini.android.capture.internal.camera.view.FlashButtonHelper.FlashButtonPosition;
+import net.gini.android.capture.internal.camera.view.HintPopup;
 import net.gini.android.capture.internal.camera.view.QRCodePopup;
 import net.gini.android.capture.internal.fileimport.FileChooserActivity;
 import net.gini.android.capture.internal.network.AnalysisNetworkRequestResult;
@@ -92,6 +93,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import jersey.repackaged.jsr166e.CompletableFuture;
 import kotlin.Unit;
+import kotlin.jvm.functions.Function0;
 import kotlin.jvm.functions.Function1;
 
 import static android.app.Activity.RESULT_CANCELED;
@@ -146,7 +148,8 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     };
 
     private static final int REQ_CODE_CHOOSE_FILE = 1;
-    private static final String SHOW_HINT_POP_UP = "SHOW_HINT_POP_UP";
+    private static final String SHOW_UPLOAD_HINT_POP_UP = "SHOW_HINT_POP_UP";
+    private static final String SHOW_QRCODE_SCANNER_HINT_POP_UP = "SHOW_QR_CODE_SCANNER_HINT_POP_UP";
     private static final String IN_MULTI_PAGE_STATE_KEY = "IN_MULTI_PAGE_STATE_KEY";
     private static final String IS_FLASH_ENABLED_KEY = "IS_FLASH_ENABLED_KEY";
 
@@ -180,12 +183,16 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     private View mUploadHintCloseButton;
     private View mUploadHintContainer;
     private View mUploadHintContainerArrow;
+    private View mQRCodeScannerHintCloseButton;
+    private View mQRCodeScannerHintContainer;
+    private View mQRCodeScannerHintContainerArrow;
     private View mCameraPreviewShade;
     private View mActivityIndicatorBackground;
     private ProgressBar mActivityIndicator;
-    private ViewPropertyAnimatorCompat mUploadHintContainerArrowAnimation;
     private ViewPropertyAnimatorCompat mCameraPreviewShadeAnimation;
-    private ViewPropertyAnimatorCompat mUploadHintContainerAnimation;
+
+    private HintPopup mUploadHintPopup;
+    private HintPopup mQRCodeScannerHintPopup;
 
     private ViewStubSafeInflater mViewStubInflater;
 
@@ -289,7 +296,50 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         bindViews(view);
         setInputHandlers();
         setSurfaceViewCallback();
+        createPopups();
         return view;
+    }
+
+    private void createPopups() {
+        mPaymentQRCodePopup =
+                new QRCodePopup<>(mFragment, mQRCodeDetectedPopupContainer,
+                        DEFAULT_ANIMATION_DURATION, getHideQRCodeDetectedPopupDelayMs(),
+                        getDifferentQRCodeDetectedPopupDelayMs(),
+                        new Function1<PaymentQRCodeData, Unit>() {
+                            @Override
+                            public Unit invoke(@Nullable PaymentQRCodeData paymentQRCodeData) {
+                                if (paymentQRCodeData == null) {
+                                    return null;
+                                }
+                                handlePaymentQRCodeData(paymentQRCodeData);
+                                return null;
+                            }
+                        });
+
+        mUnsupportedQRCodePopup =
+                new QRCodePopup<>(mFragment, mUnsupportedQRCodeDetectedPopupContainer,
+                        DEFAULT_ANIMATION_DURATION, getHideQRCodeDetectedPopupDelayMs(),
+                        getDifferentQRCodeDetectedPopupDelayMs());
+
+        mUploadHintPopup = new HintPopup(mUploadHintContainer, mUploadHintContainerArrow,
+                mUploadHintCloseButton, DEFAULT_ANIMATION_DURATION,
+                new Function0<Unit>() {
+                    @Override
+                    public Unit invoke() {
+                        closeUploadHintPopUp();
+                        return null;
+                    }
+                });
+
+        mQRCodeScannerHintPopup = new HintPopup(mQRCodeScannerHintContainer,
+                mQRCodeScannerHintContainerArrow, mQRCodeScannerHintCloseButton,
+                DEFAULT_ANIMATION_DURATION, new Function0<Unit>() {
+            @Override
+            public Unit invoke() {
+                closeQRCodeScannerHintPopUp();
+                return null;
+            }
+        });
     }
 
     public void onStart() {
@@ -302,25 +352,6 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         initViews();
         initCameraController(activity);
         if (isQRCodeScanningEnabled()) {
-            mPaymentQRCodePopup =
-                    new QRCodePopup<>(mFragment, mQRCodeDetectedPopupContainer,
-                            DEFAULT_ANIMATION_DURATION, getHideQRCodeDetectedPopupDelayMs(),
-                            getDifferentQRCodeDetectedPopupDelayMs(),
-                            new Function1<PaymentQRCodeData, Unit>() {
-                                @Override
-                                public Unit invoke(@Nullable PaymentQRCodeData paymentQRCodeData) {
-                                    if (paymentQRCodeData == null) {
-                                        return null;
-                                    }
-                                    handlePaymentQRCodeData(paymentQRCodeData);
-                                    return null;
-                                }
-                            });
-
-            mUnsupportedQRCodePopup =
-                    new QRCodePopup<>(mFragment, mUnsupportedQRCodeDetectedPopupContainer,
-                            DEFAULT_ANIMATION_DURATION, getHideQRCodeDetectedPopupDelayMs(),
-                            getDifferentQRCodeDetectedPopupDelayMs());
             initQRCodeReader(activity);
         }
 
@@ -346,7 +377,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
                                     mCameraPreview.setPreviewSize(previewSize);
                                     startPreview(surfaceHolder);
                                     enableTapToFocus();
-                                    showUploadHintPopUpOnFirstExecution();
+                                    showHintPopUpsOnFirstExecution();
                                     initFlashButton();
                                 } else {
                                     handleError(GiniCaptureError.ErrorCode.CAMERA_NO_PREVIEW,
@@ -438,30 +469,53 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     }
 
 
-    private void showUploadHintPopUpOnFirstExecution() {
-        if (shouldShowHintPopUp()) {
+     private void showUploadHintPopUpOnFirstExecution() {
+        if (mInterfaceHidden) {
+            return;
+        }
+        if (shouldShowUploadHintPopUp()) {
             showUploadHintPopUp();
         }
     }
 
+    private void showQrcodeScannerHintPopUpOnFirstExecution() {
+        if (mInterfaceHidden) {
+            return;
+        }
+        if (shouldShowQRCodeScannerHintPopup()) {
+            showQRCodeScannerHintPopUp();
+        }
+    }
+
+    private void showHintPopUpsOnFirstExecution() {
+        if (mInterfaceHidden) {
+            return;
+        }
+        if (shouldShowUploadHintPopUp()) {
+             showUploadHintPopUp();
+        } else if (shouldShowQRCodeScannerHintPopup()) {
+            showQRCodeScannerHintPopUp();
+         }
+     }
+
     @VisibleForTesting
     void showUploadHintPopUp() {
         disableCameraTriggerButtonAnimated(0.3f);
-        mUploadHintContainer.setVisibility(View.VISIBLE);
-        mUploadHintContainerArrow.setVisibility(View.VISIBLE);
+        disableFlashButtonAnimated(0.3f);
+        showHintPopup(mUploadHintPopup);
+    }
+
+    private void showQRCodeScannerHintPopUp() {
+        disableImportButtonAnimated(0.3f);
+        disableFlashButtonAnimated(0.3f);
+        showHintPopup(mQRCodeScannerHintPopup);
+    }
+
+    private void showHintPopup(@NonNull final HintPopup hintPopup) {
+        clearHintPopupRelatedAnimations();
+        hintPopup.show();
         mCameraPreviewShade.setVisibility(View.VISIBLE);
         mCameraPreviewShade.setClickable(true);
-        clearUploadHintPopUpAnimations();
-        mUploadHintContainerAnimation = ViewCompat.animate(
-                mUploadHintContainer)
-                .alpha(1)
-                .setDuration(DEFAULT_ANIMATION_DURATION);
-        mUploadHintContainerAnimation.start();
-        mUploadHintContainerArrowAnimation = ViewCompat.animate(
-                mUploadHintContainerArrow)
-                .alpha(1)
-                .setDuration(DEFAULT_ANIMATION_DURATION);
-        mUploadHintContainerArrowAnimation.start();
         mCameraPreviewShadeAnimation = ViewCompat.animate(
                 mCameraPreviewShade)
                 .alpha(1)
@@ -469,17 +523,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         mCameraPreviewShadeAnimation.start();
     }
 
-    private void clearUploadHintPopUpAnimations() {
-        if (mUploadHintContainerAnimation != null) {
-            mUploadHintContainerAnimation.cancel();
-            mUploadHintContainer.clearAnimation();
-            mUploadHintContainerAnimation.setListener(null);
-        }
-        if (mUploadHintContainerArrowAnimation != null) {
-            mUploadHintContainerArrowAnimation.cancel();
-            mUploadHintContainerArrow.clearAnimation();
-            mUploadHintContainerArrowAnimation.setListener(null);
-        }
+    private void clearHintPopupRelatedAnimations() {
         if (mCameraPreviewShadeAnimation != null) {
             mCameraPreviewShadeAnimation.cancel();
             mCameraPreviewShade.clearAnimation();
@@ -487,7 +531,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         }
     }
 
-    private boolean shouldShowHintPopUp() {
+    private boolean shouldShowUploadHintPopUp() {
         final Activity activity = mFragment.getActivity();
         if (activity == null) {
             return false;
@@ -499,7 +543,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         if (context != null) {
             final SharedPreferences gcSharedPrefs = context.getSharedPreferences(GC_SHARED_PREFS,
                     Context.MODE_PRIVATE);
-            return gcSharedPrefs.getBoolean(SHOW_HINT_POP_UP, true);
+            return gcSharedPrefs.getBoolean(SHOW_UPLOAD_HINT_POP_UP, true);
         }
         return false;
     }
@@ -610,7 +654,8 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
 
     void onStop() {
         closeCamera();
-        clearUploadHintPopUpAnimations();
+        clearHintPopupRelatedAnimations();
+        mUploadHintPopup.hide(null);
         if (mPaymentQRCodePopup != null) {
             mPaymentQRCodePopup.hide();
         }
@@ -722,6 +767,9 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         mUploadHintContainer = view.findViewById(R.id.gc_document_import_hint_container);
         mUploadHintContainerArrow = view.findViewById(R.id.gc_document_import_hint_container_arrow);
         mUploadHintCloseButton = view.findViewById(R.id.gc_document_import_hint_close_button);
+        mQRCodeScannerHintContainer = view.findViewById(R.id.gc_qr_code_scanner_hint_container);
+        mQRCodeScannerHintContainerArrow = view.findViewById(R.id.gc_qr_code_scanner_hint_container_arrow);
+        mQRCodeScannerHintCloseButton = view.findViewById(R.id.gc_qr_code_scanner_hint_close_button);
         mCameraPreviewShade = view.findViewById(R.id.gc_camera_preview_shade);
         mActivityIndicatorBackground =
                 view.findViewById(R.id.gc_activity_indicator_background);
@@ -781,10 +829,21 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     }
 
     private void setInputHandlers() {
+        mCameraPreviewShade.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(final View v) {
+                closeUploadHintPopUp();
+                closeQRCodeScannerHintPopUp();
+            }
+        });
         mButtonCameraTrigger.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(final View v) {
-                onCameraTriggerClicked();
+                if (mQRCodeScannerHintPopup.isShown()) {
+                    closeQRCodeScannerHintPopUp();
+                } else {
+                    onCameraTriggerClicked();
+                }
             }
         });
         mButtonCameraFlash.setOnClickListener(new View.OnClickListener() {
@@ -797,14 +856,9 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         mImportButtonContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(final View view) {
+                mUploadHintPopup.setIsLastPopup(true);
                 closeUploadHintPopUp();
                 showFileChooser();
-            }
-        });
-        mUploadHintCloseButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(final View view) {
-                closeUploadHintPopUp();
             }
         });
         mImageStack.setOnClickListener(new View.OnClickListener() {
@@ -972,51 +1026,101 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     }
 
     private void closeUploadHintPopUp() {
-        hideUploadHintPopUp(new ViewPropertyAnimatorListenerAdapter() {
-            @Override
-            public void onAnimationEnd(final View view) {
-                final Context context = view.getContext();
-                savePopUpShown(context);
-            }
-        });
+        if (!mUploadHintPopup.isShown()) {
+            return;
+        }
+        hideUploadHintPopup(new ViewPropertyAnimatorListenerAdapter() {
+             @Override
+             public void onAnimationEnd(final View view) {
+                 final Context context = view.getContext();
+                saveUploadHintPopUpShown(context);
+                if (shouldShowQRCodeScannerHintPopup()) {
+                    showQRCodeScannerHintPopUp();
+                }
+             }
+         });
+     }
+
+    private void hideUploadHintPopup(@Nullable final ViewPropertyAnimatorListenerAdapter
+                                             animatorListener) {
+         if (!mInterfaceHidden) {
+             enableCameraTriggerButtonAnimated();
+             enableFlashButtonAnimated();
+         }
+        hideHintPopup(mUploadHintPopup, animatorListener);
     }
 
-    private void hideUploadHintPopUp(@Nullable final ViewPropertyAnimatorListenerAdapter
+    private void hideHintPopup(@NonNull final HintPopup hintPopup,
+                               @Nullable final ViewPropertyAnimatorListenerAdapter
             animatorListener) {
-        if (!mInterfaceHidden) {
-            enableCameraTriggerButtonAnimated();
-        }
-        clearUploadHintPopUpAnimations();
-        mUploadHintContainerAnimation = ViewCompat.animate(mUploadHintContainer)
-                .alpha(0)
-                .setDuration(DEFAULT_ANIMATION_DURATION)
-                .setListener(new ViewPropertyAnimatorListenerAdapter() {
-                    @Override
-                    public void onAnimationEnd(final View view) {
-                        mUploadHintContainerArrow.setVisibility(View.GONE);
-                        mUploadHintContainer.setVisibility(View.GONE);
-                        mCameraPreviewShade.setVisibility(View.GONE);
-                        mCameraPreviewShade.setClickable(false);
-                        if (animatorListener != null) {
-                            animatorListener.onAnimationEnd(view);
-                        }
-                    }
-                });
-        mUploadHintContainerAnimation.start();
-        mUploadHintContainerArrowAnimation = ViewCompat.animate(mUploadHintContainerArrow)
-                .alpha(0)
-                .setDuration(DEFAULT_ANIMATION_DURATION);
-        mUploadHintContainerArrowAnimation.start();
+        clearHintPopupRelatedAnimations();
+        hintPopup.hide(new ViewPropertyAnimatorListenerAdapter() {
+            @Override
+            public void onAnimationEnd(View view) {
+                mCameraPreviewShade.setVisibility(View.GONE);
+                mCameraPreviewShade.setClickable(false);
+                if (animatorListener != null) {
+                    animatorListener.onAnimationEnd(view);
+                }
+            }
+        });
         mCameraPreviewShadeAnimation = ViewCompat.animate(mCameraPreviewShade)
                 .alpha(0)
                 .setDuration(DEFAULT_ANIMATION_DURATION);
         mCameraPreviewShadeAnimation.start();
     }
 
-    private void savePopUpShown(final Context context) {
+    private void closeQRCodeScannerHintPopUp() {
+        if (!mQRCodeScannerHintPopup.isShown()) {
+            return;
+        }
+        hideQRCodeScannerHintPopup(new ViewPropertyAnimatorListenerAdapter() {
+            @Override
+            public void onAnimationEnd(final View view) {
+                final Context context = view.getContext();
+                saveQRCodeScannerHintPopUpShown(context);
+            }
+        });
+    }
+
+    private boolean shouldShowQRCodeScannerHintPopup() {
+        final Activity activity = mFragment.getActivity();
+        if (activity == null) {
+            return false;
+        }
+        if (!isQRCodeScanningEnabled()
+                || mInterfaceHidden
+                || mUploadHintPopup.isLastPopup()) {
+            return false;
+        }
+        final Context context = mFragment.getActivity();
+        if (context != null) {
+            final SharedPreferences gcSharedPrefs = context.getSharedPreferences(GC_SHARED_PREFS,
+                    Context.MODE_PRIVATE);
+            return gcSharedPrefs.getBoolean(SHOW_QRCODE_SCANNER_HINT_POP_UP, true);
+        }
+        return false;
+    }
+
+    private void hideQRCodeScannerHintPopup(@Nullable final ViewPropertyAnimatorListenerAdapter
+                                             animatorListener) {
+        if (!mInterfaceHidden) {
+            enableFlashButtonAnimated();
+            enableImportButtonAnimated();
+        }
+        hideHintPopup(mQRCodeScannerHintPopup, animatorListener);
+    }
+
+    private void saveUploadHintPopUpShown(final Context context) {
+         final SharedPreferences gcSharedPrefs = context.getSharedPreferences(GC_SHARED_PREFS,
+                 Context.MODE_PRIVATE);
+        gcSharedPrefs.edit().putBoolean(SHOW_UPLOAD_HINT_POP_UP, false).apply();
+    }
+
+    private void saveQRCodeScannerHintPopUpShown(final Context context) {
         final SharedPreferences gcSharedPrefs = context.getSharedPreferences(GC_SHARED_PREFS,
                 Context.MODE_PRIVATE);
-        gcSharedPrefs.edit().putBoolean(SHOW_HINT_POP_UP, false).apply();
+        gcSharedPrefs.edit().putBoolean(SHOW_QRCODE_SCANNER_HINT_POP_UP, false).apply();
     }
 
     private void showFileChooser() {
@@ -1350,22 +1454,26 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     private void enableInteraction() {
         if (mCameraPreview == null
                 || mButtonImportDocument == null
+                || mImportButtonContainer == null
                 || mButtonCameraTrigger == null) {
             return;
         }
         mCameraPreview.setEnabled(true);
         mButtonImportDocument.setEnabled(true);
+        mImportButtonContainer.setEnabled(true);
         mButtonCameraTrigger.setEnabled(true);
     }
 
     private void disableInteraction() {
         if (mCameraPreview == null
                 || mButtonImportDocument == null
+                || mImportButtonContainer == null
                 || mButtonCameraTrigger == null) {
             return;
         }
         mCameraPreview.setEnabled(false);
         mButtonImportDocument.setEnabled(false);
+        mImportButtonContainer.setEnabled(false);
         mButtonCameraTrigger.setEnabled(false);
     }
 
@@ -1586,6 +1694,32 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         mButtonCameraTrigger.setEnabled(true);
     }
 
+    private void disableFlashButtonAnimated(final float alpha) {
+        mButtonCameraFlash.clearAnimation();
+        mButtonCameraFlash.animate().alpha(alpha).start();
+        mButtonCameraFlash.setEnabled(false);
+    }
+
+    private void enableFlashButtonAnimated() {
+        mButtonCameraFlash.clearAnimation();
+        mButtonCameraFlash.animate().alpha(1.0f).start();
+        mButtonCameraFlash.setEnabled(true);
+    }
+
+    private void enableImportButtonAnimated() {
+        mImportButtonContainer.clearAnimation();
+        mImportButtonContainer.animate().alpha(1.0f).start();
+        mButtonImportDocument.setEnabled(true);
+        mImportButtonContainer.setEnabled(true);
+    }
+
+    private void disableImportButtonAnimated(final float alpha) {
+        mImportButtonContainer.clearAnimation();
+        mImportButtonContainer.animate().alpha(alpha).start();
+        mButtonImportDocument.setEnabled(false);
+        mImportButtonContainer.setEnabled(false);
+    }
+
     @Override
     public void showInterface() {
         if (!mInterfaceHidden || isNoPermissionViewVisible()) {
@@ -1599,11 +1733,13 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         showCameraTriggerButtonAnimated();
         showDocumentCornerGuidesAnimated();
         showImageStackAnimated();
+        showFlashButtonAnimated();
         if (mImportDocumentButtonEnabled) {
             showUploadHintPopUpOnFirstExecution();
             showImportDocumentButtonAnimated();
+        } else {
+            showQrcodeScannerHintPopUpOnFirstExecution();
         }
-        showFlashButtonAnimated();
     }
 
     private void showImageStackAnimated() {
@@ -1613,6 +1749,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     private void showImportDocumentButtonAnimated() {
         mImportButtonContainer.animate().alpha(1.0f);
         mButtonImportDocument.setEnabled(true);
+        mImportButtonContainer.setEnabled(true);
     }
 
     private void showFlashButtonAnimated() {
@@ -1634,9 +1771,10 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
         hideDocumentCornerGuidesAnimated();
         hideImageStackAnimated();
         if (mImportDocumentButtonEnabled) {
-            hideUploadHintPopUp(null);
+            hideUploadHintPopup(null);
             hideImportDocumentButtonAnimated();
         }
+        hideQRCodeScannerHintPopup(null);
         hideFlashButtonAnimated();
     }
 
@@ -1647,6 +1785,7 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     private void hideImportDocumentButtonAnimated() {
         mImportButtonContainer.animate().alpha(0.0f);
         mButtonImportDocument.setEnabled(false);
+        mImportButtonContainer.setEnabled(false);
     }
 
     private void showNoPermissionView() {

--- a/ginicapture/src/main/java/net/gini/android/capture/help/SupportedFormatsAdapter.java
+++ b/ginicapture/src/main/java/net/gini/android/capture/help/SupportedFormatsAdapter.java
@@ -24,6 +24,7 @@ import static net.gini.android.capture.help.SupportedFormatsAdapter.ItemType.FOR
 import static net.gini.android.capture.help.SupportedFormatsAdapter.ItemType.HEADER;
 import static net.gini.android.capture.internal.util.FeatureConfiguration.getDocumentImportEnabledFileTypes;
 import static net.gini.android.capture.internal.util.FeatureConfiguration.isFileImportEnabled;
+import static net.gini.android.capture.internal.util.FeatureConfiguration.isQRCodeScanningEnabled;
 
 /**
  * Internal use only.
@@ -51,6 +52,9 @@ class SupportedFormatsAdapter extends
         } else if (getDocumentImportEnabledFileTypes()
                 == DocumentImportEnabledFileTypes.PDF) {
             items.add(SupportedFormat.PDF);
+        }
+        if (isQRCodeScanningEnabled()) {
+            items.add(SupportedFormat.QR_CODE);
         }
         items.add(SectionHeader.UNSUPPORTED_FORMATS);
         Collections.addAll(items, UnsupportedFormat.values());
@@ -142,7 +146,8 @@ class SupportedFormatsAdapter extends
     private enum SupportedFormat implements FormatInfo {
         PRINTED_INVOICES(R.string.gc_supported_format_printed_invoices),
         SINGLE_PAGE_AS_JPEG_PNG_GIF(R.string.gc_supported_format_single_page_as_jpeg_png_gif),
-        PDF(R.string.gc_supported_format_pdf);
+        PDF(R.string.gc_supported_format_pdf),
+        QR_CODE(R.string.gc_supported_format_qr_code);
 
         @DrawableRes
         private final int mIconBackground;

--- a/ginicapture/src/main/java/net/gini/android/capture/internal/camera/view/HintPopup.kt
+++ b/ginicapture/src/main/java/net/gini/android/capture/internal/camera/view/HintPopup.kt
@@ -1,0 +1,96 @@
+package net.gini.android.capture.internal.camera.view
+
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.ViewPropertyAnimatorCompat
+import androidx.core.view.ViewPropertyAnimatorListenerAdapter
+
+/**
+ * Internal use only.
+ *
+ * @suppress
+ */
+internal class HintPopup(
+        private val popupView: View,
+        private val popupArrow: View,
+        closeButton: View,
+        private val animationDuration: Long,
+        private val onCloseClicked: () -> Unit) {
+
+    private var popupAnimation: ViewPropertyAnimatorCompat? = null
+    private var popupArrowAnimation: ViewPropertyAnimatorCompat? = null
+
+    var isShown = false
+        private set
+
+    var isLastPopup = false
+        @JvmName("setIsLastPopup") set
+
+    init {
+        closeButton.setOnClickListener {
+            onCloseClicked()
+        }
+    }
+
+    fun show() {
+        popupView.visibility = View.VISIBLE
+        popupArrow.visibility = View.VISIBLE
+        clearUploadHintPopUpAnimations()
+        popupArrowAnimation = ViewCompat.animate(
+                popupView)
+                .alpha(1f)
+                .setDuration(animationDuration)
+                .setListener(object: ViewPropertyAnimatorListenerAdapter() {
+                    override fun onAnimationEnd(view: View?) {
+                        isShown = true
+                    }
+                })
+                .apply {
+                    start()
+                }
+        popupAnimation = ViewCompat.animate(
+                popupArrow)
+                .alpha(1f)
+                .setDuration(animationDuration)
+                .apply {
+                    start()
+                }
+    }
+
+    fun hide(animatorListener: ViewPropertyAnimatorListenerAdapter?) {
+        clearUploadHintPopUpAnimations()
+        popupArrowAnimation = ViewCompat.animate(popupView)
+                .alpha(0f)
+                .setDuration(animationDuration)
+                .setListener(object : ViewPropertyAnimatorListenerAdapter() {
+                    override fun onAnimationEnd(view: View) {
+                        isShown = false
+                        popupArrow.visibility = View.GONE
+                        popupView.visibility = View.GONE
+                        animatorListener?.onAnimationEnd(view)
+                    }
+                })
+                .apply {
+                    start()
+                }
+        popupAnimation = ViewCompat.animate(popupArrow)
+                .alpha(0f)
+                .setDuration(animationDuration)
+                .apply {
+                    start()
+                }
+    }
+
+    private fun clearUploadHintPopUpAnimations() {
+        popupArrowAnimation?.apply {
+            cancel()
+            popupView.clearAnimation()
+            setListener(null)
+        }
+        popupAnimation?.apply {
+            cancel()
+            popupView.clearAnimation()
+            setListener(null)
+        }
+    }
+}

--- a/ginicapture/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
+++ b/ginicapture/src/main/java/net/gini/android/capture/internal/camera/view/QRCodePopup.kt
@@ -1,0 +1,116 @@
+package net.gini.android.capture.internal.camera.view
+
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.ViewPropertyAnimatorCompat
+import androidx.core.view.ViewPropertyAnimatorListener
+import androidx.core.view.ViewPropertyAnimatorListenerAdapter
+import net.gini.android.capture.internal.ui.FragmentImplCallback
+
+/**
+ * Internal use only.
+ *
+ * @suppress
+ */
+internal class QRCodePopup<T> @JvmOverloads constructor(
+        private val fragmentImplCallback: FragmentImplCallback,
+        private val popupView: View,
+        private val animationDuration: Long,
+        private val hideDelayMs: Long,
+        private val showAgainDelayMs: Long,
+        private val onClicked: (T?) -> Unit = {}) {
+
+    private var animation: ViewPropertyAnimatorCompat? = null
+    private val hideRunnable: Runnable = Runnable {
+        hide()
+    }
+
+    var qrCodeContent: T? = null
+        private set
+
+    var isShown = false
+        private set
+
+    init {
+        popupView.setOnClickListener {
+            onClicked(qrCodeContent)
+            hide()
+        }
+    }
+
+    @JvmOverloads
+    fun show(qrCodeContent: T, startDelay: Long = 0) {
+        if (this.qrCodeContent != null && qrCodeContent != this.qrCodeContent) {
+            hide(object : ViewPropertyAnimatorListenerAdapter() {
+                override fun onAnimationEnd(view: View?) {
+                    show(showAgainDelayMs)
+                }
+            })
+        } else {
+            show(startDelay)
+        }
+
+        this.qrCodeContent = qrCodeContent
+    }
+
+    private fun show(startDelay: Long = 0) {
+        if (popupView.alpha != 0f) {
+            fragmentImplCallback.view?.removeCallbacks(hideRunnable)
+            fragmentImplCallback.view?.postDelayed(hideRunnable, hideDelayMs)
+            return
+        }
+
+        clearQRCodeDetectedPopUpAnimation()
+        popupView.visibility = View.VISIBLE
+        animation = ViewCompat.animate(popupView)
+                .alpha(1.0f)
+                .setStartDelay(startDelay)
+                .setDuration(animationDuration)
+                .setListener(object : ViewPropertyAnimatorListenerAdapter() {
+                    override fun onAnimationEnd(view: View?) {
+                        isShown = true
+                    }
+                })
+                .apply {
+                    start()
+                }
+
+        fragmentImplCallback.view?.removeCallbacks(hideRunnable)
+        fragmentImplCallback.view?.postDelayed(hideRunnable, hideDelayMs)
+    }
+
+    @JvmOverloads
+    fun hide(animatorListener: ViewPropertyAnimatorListener? = null) {
+        qrCodeContent = null
+
+        if (popupView.alpha != 1f) {
+            animatorListener?.onAnimationEnd(popupView)
+            return
+        }
+        clearQRCodeDetectedPopUpAnimation()
+        animation = ViewCompat.animate(popupView)
+                .alpha(0.0f)
+                .setDuration(animationDuration)
+                .setListener(object : ViewPropertyAnimatorListenerAdapter() {
+                    override fun onAnimationEnd(view: View) {
+                        popupView.visibility = View.GONE
+                        isShown = false
+                        animatorListener?.onAnimationEnd(view)
+                    }
+                })
+                .apply {
+                    start()
+                }
+
+        fragmentImplCallback.view?.removeCallbacks(hideRunnable)
+    }
+
+    private fun clearQRCodeDetectedPopUpAnimation() {
+        animation?.apply {
+            cancel()
+            popupView.clearAnimation()
+            setListener(null)
+        }
+        fragmentImplCallback.view?.removeCallbacks(hideRunnable)
+    }
+}

--- a/ginicapture/src/main/java/net/gini/android/capture/internal/qrcode/PaymentQRCodeReader.java
+++ b/ginicapture/src/main/java/net/gini/android/capture/internal/qrcode/PaymentQRCodeReader.java
@@ -32,6 +32,10 @@ public class PaymentQRCodeReader {
         public void onPaymentQRCodeDataAvailable(
                 @NonNull final PaymentQRCodeData paymentQRCodeData) {
         }
+
+        @Override
+        public void onNonPaymentQRCodeDetected(@NonNull final String qrCodeContent) {
+        }
     };
 
     /**
@@ -62,6 +66,7 @@ public class PaymentQRCodeReader {
                         mListener.onPaymentQRCodeDataAvailable(paymentData);
                         return;
                     } catch (final IllegalArgumentException ignored) {
+                        mListener.onNonPaymentQRCodeDetected(qrCodeContent);
                     }
                 }
             }
@@ -109,5 +114,12 @@ public class PaymentQRCodeReader {
          * @param paymentQRCodeData the payment data found on the image
          */
         void onPaymentQRCodeDataAvailable(@NonNull final PaymentQRCodeData paymentQRCodeData);
+
+        /**
+         * Called when a QRCode was found without a supported payment data format.
+         *
+         * @param qrCodeContent the content of the QRCode
+         */
+        void onNonPaymentQRCodeDetected(@NonNull final String qrCodeContent);
     }
 }

--- a/ginicapture/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
+++ b/ginicapture/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
@@ -148,6 +148,57 @@
 
     </RelativeLayout>
 
+    <RelativeLayout
+        android:id="@+id/gc_unsupported_qrcode_detected_popup_container"
+        android:layout_width="@dimen/gc_camera_qrcode_detected_popup_width"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="@dimen/gc_camera_qrcode_detected_popup_vertical_margin"
+        android:alpha="0"
+        android:background="@color/gc_unsupported_qrcode_detected_popup_background"
+        android:paddingBottom="@dimen/gc_camera_qrcode_detected_popup_vertical_padding"
+        android:paddingLeft="@dimen/gc_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingRight="@dimen/gc_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingTop="@dimen/gc_camera_qrcode_detected_popup_vertical_padding"
+        android:visibility="gone"
+        tools:alpha="1"
+        tools:visibility="visible">
+
+        <ImageView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_icon"
+            android:layout_width="@dimen/gc_camera_qrcode_icon_size"
+            android:layout_height="@dimen/gc_camera_qrcode_icon_size"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:src="@drawable/qr_code_icon"
+            tools:ignore="ContentDescription" />
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_1"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginLeft="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginRight="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginStart="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_toEndOf="@id/gc_camera_unsupported_qrcode_detected_popup_icon"
+            android:layout_toStartOf="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
+            android:text="@string/gc_unsupported_qrcode_detected_popup_message_1" />
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:text="@string/gc_unsupported_qrcode_detected_popup_message_2" />
+
+    </RelativeLayout>
+
     <View
         android:id="@+id/gc_image_stack_placeholder"
         android:layout_width="wrap_content"
@@ -169,7 +220,7 @@
         android:layout_alignEnd="@id/gc_image_stack_placeholder"
         android:layout_marginStart="@dimen/gc_camera_image_stack_left_margin"
         android:layout_marginTop="@dimen/gc_camera_image_stack_top_margin"
-        tools:visibility="visible" />
+        tools:visibility="gone" />
 
     <LinearLayout
         android:id="@+id/gc_document_import_button_container"

--- a/ginicapture/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
+++ b/ginicapture/src/main/res/layout-sw600dp-land/gc_fragment_camera.xml
@@ -1,5 +1,6 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/gc_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -53,7 +54,7 @@
         android:alpha="0"
         android:scaleType="centerInside"
         android:src="@drawable/gc_hint_arrow_right"
-        android:tint="@color/gc_document_import_hint_background"
+        app:tint="@color/gc_document_import_hint_background"
         android:visibility="gone"
         tools:alpha="1"
         tools:visibility="visible" />
@@ -93,7 +94,62 @@
             android:layout_centerVertical="true"
             android:padding="@dimen/gc_camera_upload_hint_container_close_button_padding"
             android:src="@drawable/gc_hint_close"
-            android:tint="@color/gc_hint_close" />
+            app:tint="@color/gc_hint_close" />
+
+    </RelativeLayout>
+
+    <ImageView
+        android:id="@+id/gc_qr_code_scanner_hint_container_arrow"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignBottom="@+id/gc_button_camera_trigger"
+        android:layout_alignTop="@+id/gc_button_camera_trigger"
+        android:layout_toStartOf="@id/gc_button_camera_trigger"
+        android:layout_marginEnd="@dimen/gc_camera_qr_code_scanner_hint_arrow_margin"
+        android:alpha="0"
+        android:scaleType="centerInside"
+        android:src="@drawable/gc_hint_arrow_right"
+        app:tint="@color/gc_document_import_hint_background"
+        android:visibility="gone"
+        tools:alpha="1"
+        tools:visibility="visible" />
+
+    <RelativeLayout
+        android:id="@+id/gc_qr_code_scanner_hint_container"
+        android:layout_width="@dimen/gc_camera_upload_hint_container_width"
+        android:layout_height="wrap_content"
+        android:layout_alignTop="@+id/gc_qr_code_scanner_hint_container_arrow"
+        android:layout_marginTop="@dimen/gc_camera_upload_hint_container_top_margin"
+        android:layout_toStartOf="@+id/gc_qr_code_scanner_hint_container_arrow"
+        android:alpha="0"
+        android:background="@color/gc_document_import_hint_background"
+        android:paddingBottom="@dimen/gc_camera_upload_hint_container_padding"
+        android:paddingEnd="@dimen/gc_camera_upload_hint_container_padding_right"
+        android:paddingStart="@dimen/gc_camera_upload_hint_container_padding"
+        android:paddingTop="@dimen/gc_camera_upload_hint_container_padding"
+        android:visibility="gone"
+        tools:alpha="1"
+        tools:visibility="visible">
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            style="@style/GiniCaptureTheme.Camera.DocumentImportHint.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="@dimen/gc_camera_upload_hint_text_right_margin"
+            android:layout_toStartOf="@+id/gc_qr_code_scanner_hint_close_button"
+            android:text="@string/gc_qr_code_scanner_hint_text" />
+
+        <ImageView
+            android:id="@+id/gc_qr_code_scanner_hint_close_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:padding="@dimen/gc_camera_upload_hint_container_close_button_padding"
+            android:src="@drawable/gc_hint_close"
+            app:tint="@color/gc_hint_close" />
 
     </RelativeLayout>
 
@@ -176,7 +232,7 @@
 
         <net.gini.android.capture.internal.ui.CustomFontTextView
             android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_1"
-            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle"
+            style="@style/GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
@@ -190,7 +246,7 @@
 
         <net.gini.android.capture.internal.ui.CustomFontTextView
             android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
-            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle"
+            style="@style/GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"

--- a/ginicapture/src/main/res/layout-sw600dp/gc_fragment_camera.xml
+++ b/ginicapture/src/main/res/layout-sw600dp/gc_fragment_camera.xml
@@ -1,5 +1,6 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/gc_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -95,7 +96,7 @@
         android:layout_alignStart="@+id/gc_document_import_button_container"
         android:alpha="0"
         android:src="@drawable/gc_hint_arrow_down"
-        android:tint="@color/gc_document_import_hint_background"
+        app:tint="@color/gc_document_import_hint_background"
         android:visibility="gone"
         tools:alpha="1"
         tools:visibility="visible" />
@@ -135,7 +136,61 @@
             android:layout_centerVertical="true"
             android:padding="@dimen/gc_camera_upload_hint_container_close_button_padding"
             android:src="@drawable/gc_hint_close"
-            android:tint="@color/gc_hint_close" />
+            app:tint="@color/gc_hint_close" />
+
+    </RelativeLayout>
+
+    <ImageView
+        android:id="@+id/gc_qr_code_scanner_hint_container_arrow"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/gc_button_camera_trigger"
+        android:layout_alignEnd="@+id/gc_button_camera_trigger"
+        android:layout_alignStart="@+id/gc_button_camera_trigger"
+        android:layout_marginBottom="@dimen/gc_camera_qr_code_scanner_hint_arrow_margin"
+        android:alpha="0"
+        android:src="@drawable/gc_hint_arrow_down"
+        app:tint="@color/gc_document_import_hint_background"
+        android:visibility="gone"
+        tools:alpha="1"
+        tools:visibility="visible" />
+
+    <RelativeLayout
+        android:id="@+id/gc_qr_code_scanner_hint_container"
+        android:layout_width="512dp"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/gc_qr_code_scanner_hint_container_arrow"
+        android:layout_centerInParent="true"
+        android:alpha="0"
+        android:background="@color/gc_document_import_hint_background"
+        android:paddingBottom="@dimen/gc_camera_upload_hint_container_padding"
+        android:paddingEnd="@dimen/gc_camera_upload_hint_container_padding_right"
+        android:paddingStart="@dimen/gc_camera_upload_hint_container_padding"
+        android:paddingTop="@dimen/gc_camera_upload_hint_container_padding"
+        android:visibility="gone"
+        tools:alpha="1"
+        tools:visibility="visible">
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            style="@style/GiniCaptureTheme.Camera.DocumentImportHint.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_centerHorizontal="true"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="@dimen/gc_camera_upload_hint_text_right_margin"
+            android:layout_toStartOf="@+id/gc_qr_code_scanner_hint_close_button"
+            android:text="@string/gc_qr_code_scanner_hint_text" />
+
+        <ImageView
+            android:id="@+id/gc_qr_code_scanner_hint_close_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:padding="@dimen/gc_camera_upload_hint_container_close_button_padding"
+            android:src="@drawable/gc_hint_close"
+            app:tint="@color/gc_hint_close" />
 
     </RelativeLayout>
 
@@ -217,7 +272,7 @@
 
         <net.gini.android.capture.internal.ui.CustomFontTextView
             android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_1"
-            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle"
+            style="@style/GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
@@ -231,7 +286,7 @@
 
         <net.gini.android.capture.internal.ui.CustomFontTextView
             android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
-            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle"
+            style="@style/GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"

--- a/ginicapture/src/main/res/layout-sw600dp/gc_fragment_camera.xml
+++ b/ginicapture/src/main/res/layout-sw600dp/gc_fragment_camera.xml
@@ -189,6 +189,57 @@
 
     </RelativeLayout>
 
+    <RelativeLayout
+        android:id="@+id/gc_unsupported_qrcode_detected_popup_container"
+        android:layout_width="@dimen/gc_camera_qrcode_detected_popup_width"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/gc_button_camera_trigger"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="@dimen/gc_camera_qrcode_detected_popup_vertical_margin"
+        android:alpha="0"
+        android:background="@color/gc_unsupported_qrcode_detected_popup_background"
+        android:paddingBottom="@dimen/gc_camera_qrcode_detected_popup_vertical_padding"
+        android:paddingLeft="@dimen/gc_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingRight="@dimen/gc_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingTop="@dimen/gc_camera_qrcode_detected_popup_vertical_padding"
+        android:visibility="gone"
+        tools:alpha="1"
+        tools:visibility="invisible">
+
+        <ImageView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_icon"
+            android:layout_width="@dimen/gc_camera_qrcode_icon_size"
+            android:layout_height="@dimen/gc_camera_qrcode_icon_size"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:src="@drawable/qr_code_icon"
+            tools:ignore="ContentDescription" />
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_1"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginLeft="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginRight="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginStart="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_toEndOf="@id/gc_camera_unsupported_qrcode_detected_popup_icon"
+            android:layout_toStartOf="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
+            android:text="@string/gc_unsupported_qrcode_detected_popup_message_1" />
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:text="@string/gc_unsupported_qrcode_detected_popup_message_2" />
+
+    </RelativeLayout>
+
     <View
         android:id="@+id/gc_image_stack_placeholder"
         android:layout_width="60dp"
@@ -209,7 +260,7 @@
         android:layout_alignEnd="@id/gc_image_stack_placeholder"
         android:layout_marginStart="@dimen/gc_camera_image_stack_left_margin"
         android:layout_marginTop="@dimen/gc_camera_image_stack_top_margin"
-        tools:visibility="visible" />
+        tools:visibility="gone" />
 
     <LinearLayout
         android:id="@+id/gc_document_import_button_container"

--- a/ginicapture/src/main/res/layout/gc_fragment_camera.xml
+++ b/ginicapture/src/main/res/layout/gc_fragment_camera.xml
@@ -1,5 +1,6 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/gc_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -103,7 +104,7 @@
         android:layout_alignStart="@+id/gc_document_import_button_container"
         android:alpha="0"
         android:src="@drawable/gc_hint_arrow_down"
-        android:tint="@color/gc_document_import_hint_background"
+        app:tint="@color/gc_document_import_hint_background"
         android:visibility="gone"
         tools:alpha="1"
         tools:visibility="visible" />
@@ -143,7 +144,7 @@
             android:layout_centerVertical="true"
             android:padding="@dimen/gc_camera_upload_hint_container_close_button_padding"
             android:src="@drawable/gc_hint_close"
-            android:tint="@color/gc_hint_close" />
+            app:tint="@color/gc_hint_close" />
 
     </RelativeLayout>
 
@@ -193,6 +194,56 @@
             android:layout_alignParentEnd="true"
             android:layout_centerVertical="true"
             android:text="@string/gc_qrcode_detected_popup_message_2" />
+
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/gc_unsupported_qrcode_detected_popup_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/gc_button_camera_trigger"
+        android:layout_marginBottom="@dimen/gc_camera_qrcode_detected_popup_vertical_margin"
+        android:layout_marginLeft="@dimen/gc_camera_qrcode_detected_popup_horizontal_margin"
+        android:layout_marginRight="@dimen/gc_camera_qrcode_detected_popup_horizontal_margin"
+        android:alpha="0"
+        android:background="@color/gc_unsupported_qrcode_detected_popup_background"
+        android:paddingBottom="@dimen/gc_camera_qrcode_detected_popup_vertical_padding"
+        android:paddingLeft="@dimen/gc_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingRight="@dimen/gc_camera_qrcode_detected_popup_horizontal_padding"
+        android:paddingTop="@dimen/gc_camera_qrcode_detected_popup_vertical_padding"
+        android:visibility="gone">
+
+        <ImageView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_icon"
+            android:layout_width="@dimen/gc_camera_qrcode_icon_size"
+            android:layout_height="@dimen/gc_camera_qrcode_icon_size"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:src="@drawable/qr_code_icon"
+            tools:ignore="ContentDescription" />
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_1"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginLeft="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginRight="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_marginStart="@dimen/gc_camera_qrcode_detected_popup_text_horizontal_margin"
+            android:layout_toEndOf="@id/gc_camera_unsupported_qrcode_detected_popup_icon"
+            android:layout_toStartOf="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
+            android:text="@string/gc_unsupported_qrcode_detected_popup_message_1" />
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
+            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:text="@string/gc_unsupported_qrcode_detected_popup_message_2" />
 
     </RelativeLayout>
 

--- a/ginicapture/src/main/res/layout/gc_fragment_camera.xml
+++ b/ginicapture/src/main/res/layout/gc_fragment_camera.xml
@@ -148,6 +148,60 @@
 
     </RelativeLayout>
 
+    <ImageView
+        android:id="@+id/gc_qr_code_scanner_hint_container_arrow"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/gc_button_camera_trigger"
+        android:layout_alignEnd="@+id/gc_button_camera_trigger"
+        android:layout_alignStart="@+id/gc_button_camera_trigger"
+        android:layout_marginBottom="@dimen/gc_camera_qr_code_scanner_hint_arrow_margin"
+        android:alpha="0"
+        android:src="@drawable/gc_hint_arrow_down"
+        app:tint="@color/gc_document_import_hint_background"
+        android:visibility="gone"
+        tools:alpha="1"
+        tools:visibility="visible" />
+
+    <RelativeLayout
+        android:id="@+id/gc_qr_code_scanner_hint_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@id/gc_qr_code_scanner_hint_container_arrow"
+        android:layout_marginLeft="@dimen/gc_camera_upload_hint_container_horizontal_margin"
+        android:layout_marginRight="@dimen/gc_camera_upload_hint_container_horizontal_margin"
+        android:alpha="0"
+        android:background="@color/gc_document_import_hint_background"
+        android:paddingBottom="@dimen/gc_camera_upload_hint_container_padding"
+        android:paddingEnd="@dimen/gc_camera_upload_hint_container_padding_right"
+        android:paddingStart="@dimen/gc_camera_upload_hint_container_padding"
+        android:paddingTop="@dimen/gc_camera_upload_hint_container_padding"
+        android:visibility="gone"
+        tools:alpha="1"
+        tools:visibility="visible">
+
+        <net.gini.android.capture.internal.ui.CustomFontTextView
+            style="@style/GiniCaptureTheme.Camera.DocumentImportHint.TextStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true"
+            android:layout_marginEnd="@dimen/gc_camera_upload_hint_text_right_margin"
+            android:layout_toStartOf="@+id/gc_qr_code_scanner_hint_close_button"
+            android:text="@string/gc_qr_code_scanner_hint_text" />
+
+        <ImageView
+            android:id="@+id/gc_qr_code_scanner_hint_close_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:padding="@dimen/gc_camera_upload_hint_container_close_button_padding"
+            android:src="@drawable/gc_hint_close"
+            app:tint="@color/gc_hint_close" />
+
+    </RelativeLayout>
+
     <RelativeLayout
         android:id="@+id/gc_qrcode_detected_popup_container"
         android:layout_width="match_parent"
@@ -224,7 +278,7 @@
 
         <net.gini.android.capture.internal.ui.CustomFontTextView
             android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_1"
-            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle"
+            style="@style/GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
@@ -238,7 +292,7 @@
 
         <net.gini.android.capture.internal.ui.CustomFontTextView
             android:id="@+id/gc_camera_unsupported_qrcode_detected_popup_message_2"
-            style="@style/GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle"
+            style="@style/GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"

--- a/ginicapture/src/main/res/values-en/strings.xml
+++ b/ginicapture/src/main/res/values-en/strings.xml
@@ -17,6 +17,8 @@
     <string name="gc_document_error_multi_page_limit_cancel_button">Cancel</string>
     <string name="gc_qrcode_detected_popup_message_1">Use QR code?</string>
     <string name="gc_qrcode_detected_popup_message_2">Continue</string>
+    <string name="gc_unsupported_qrcode_detected_popup_message_1">This QR Code does not contain any payment information.</string>
+    <string name="gc_unsupported_qrcode_detected_popup_message_2">X</string>
     <string name="gc_onboarding_lighting">Ensure good lighting when photographing the invoice or remittance slip</string>
     <string name="gc_onboarding_flat">Flatten the page</string>
     <string name="gc_onboarding_parallel">Hold device parallel over the page</string>

--- a/ginicapture/src/main/res/values-en/strings.xml
+++ b/ginicapture/src/main/res/values-en/strings.xml
@@ -45,6 +45,7 @@
     <string name="gc_noresults_headline">Tips for best results:</string>
     <string name="gc_noresults_back_button">To the camera</string>
     <string name="gc_document_import_hint_text">Now documents can be conveniently uploaded for analysis.</string>
+    <string name="gc_qr_code_scanner_hint_text">Have you checked out the QR code scanner yet?</string>
     <string name="gc_document_import_error">The document could not be opened. Please try a different document.</string>
     <string name="gc_storage_permission_denied">Permission to access files is required to upload saved invoices.</string>
     <string name="gc_storage_permission_denied_positive_button">Grant permission</string>
@@ -76,6 +77,7 @@
     <string name="gc_supported_format_printed_invoices">Computer-generated invoices and remittance slips</string>
     <string name="gc_supported_format_single_page_as_jpeg_png_gif">1-sided photos of format jpeg, png or gif</string>
     <string name="gc_supported_format_pdf">PDF documents of up to 10 pages</string>
+    <string name="gc_supported_format_qr_code">QR Codes</string>
     <string name="gc_unsupported_format_handwriting">Handwriting</string>
     <string name="gc_unsupported_format_photos_of_screens">Photos of monitors or screens</string>
     <string name="gc_supported_format_section_header">The following formats are supported:</string>

--- a/ginicapture/src/main/res/values/colors.xml
+++ b/ginicapture/src/main/res/values/colors.xml
@@ -27,6 +27,10 @@
     <color name="gc_qrcode_detected_popup_message_1">#000</color>
     <color name="gc_qrcode_detected_popup_message_2">#009edc</color>
 
+    <color name="gc_unsupported_qrcode_detected_popup_background">#eeffffff</color>
+    <color name="gc_unsupported_qrcode_detected_popup_message_1">#e30b5d</color>
+    <color name="gc_unsupported_qrcode_detected_popup_message_2">#e30b5d</color>
+
     <color name="gc_document_import_hint_background">#ffffff</color>
     <color name="gc_document_import_hint_text">#000000</color>
 

--- a/ginicapture/src/main/res/values/dimens.xml
+++ b/ginicapture/src/main/res/values/dimens.xml
@@ -7,6 +7,7 @@
     <dimen name="gc_camera_upload_hint_container_padding_right">16dp</dimen>
     <dimen name="gc_camera_upload_hint_container_close_button_padding">8dp</dimen>
     <dimen name="gc_camera_upload_hint_text_right_margin">8dp</dimen>
+    <dimen name="gc_camera_qr_code_scanner_hint_arrow_margin">8dp</dimen>
     <dimen name="gc_camera_upload_button_size">48dp</dimen>
     <dimen name="gc_camera_upload_button_left_margin">40dp</dimen>
     <dimen name="gc_camera_upload_button_top_margin">0dp</dimen>

--- a/ginicapture/src/main/res/values/strings.xml
+++ b/ginicapture/src/main/res/values/strings.xml
@@ -18,12 +18,16 @@
     <string name="gc_camera_error_no_permission_button_title">Zugriff erlauben</string>
     <string name="gc_camera_image_stack_subtitle">Seiten</string>
     <string name="gc_camera_document_import_subtitle">Importieren</string>
+
     <string name="gc_document_error_multi_page_limit_review_pages_button">Seitenübersicht</string>
-
     <string name="gc_document_error_multi_page_limit_cancel_button">Abbrechen</string>
-    <string name="gc_qrcode_detected_popup_message_1">QR verwenden?</string>
 
+    <string name="gc_qrcode_detected_popup_message_1">QR verwenden?</string>
     <string name="gc_qrcode_detected_popup_message_2">Hier geht’s weiter.</string>
+
+    <string name="gc_unsupported_qrcode_detected_popup_message_1">Dieser QR-Code enthält keine Bezahlinformationen.</string>
+    <string name="gc_unsupported_qrcode_detected_popup_message_2">X</string>
+
     <string name="gc_onboarding_lighting">Beim Abfotografieren der Rechnung oder des Überweisungsträgers auf gute Beleuchtung achten</string>
     <string name="gc_onboarding_flat">Seite glatt streichen</string>
     <string name="gc_onboarding_parallel">Gerät parallel über die Seite halten</string>

--- a/ginicapture/src/main/res/values/strings.xml
+++ b/ginicapture/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
     <string name="gc_noresults_back_button">Zur Kamera</string>
 
     <string name="gc_document_import_hint_text">Es können jetzt auch ganz einfach Dateien hochgeladen werden.</string>
+    <string name="gc_qr_code_scanner_hint_text">Haben Sie schon den QR-Codeleser ausprobiert?</string>
 
     <string name="gc_document_import_error">Ihre Datei konnte nicht geöffnet werden. Bitte versuchen sie es mit einer anderen Datei.</string>
     <string name="gc_storage_permission_denied">Nur mit Datei-Zugriff können gespeicherte Rechnungen hochgeladen werden.</string>
@@ -95,6 +96,7 @@
     <string name="gc_supported_format_printed_invoices">Computer-erstellte Überweisungsträger und Rechnungen</string>
     <string name="gc_supported_format_single_page_as_jpeg_png_gif">Einseitige Bilder im jpeg, png oder gif Format</string>
     <string name="gc_supported_format_pdf">PDF Dokumente von bis zu 10 Seiten</string>
+    <string name="gc_supported_format_qr_code">QR Codes</string>
     <string name="gc_unsupported_format_handwriting">Handschrift</string>
     <string name="gc_unsupported_format_photos_of_screens">Fotos von Bildschirmen</string>
     <string name="gc_supported_format_section_header">Folgende Formate werden unterstützt:</string>

--- a/ginicapture/src/main/res/values/styles.xml
+++ b/ginicapture/src/main/res/values/styles.xml
@@ -71,6 +71,18 @@
         <item name="gcCustomFont" />
     </style>
 
+    <style name="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle" parent="TextAppearance.AppCompat">
+        <item name="android:textSize">14sp</item>
+        <item name="android:textColor">@color/gc_unsupported_qrcode_detected_popup_message_1</item>
+        <item name="gcCustomFont" />
+    </style>
+
+    <style name="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle" parent="TextAppearance.AppCompat">
+        <item name="android:textSize">14sp</item>
+        <item name="android:textColor">@color/gc_unsupported_qrcode_detected_popup_message_2</item>
+        <item name="gcCustomFont" />
+    </style>
+
     <style name="Root.GiniCaptureTheme.Camera.DocumentImportSubtitle.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textSize">12sp</item>
         <item name="android:textColor">@color/gc_camera_document_import_subtitle_text</item>
@@ -253,6 +265,10 @@
     <style name="GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle" parent="Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message1.TextStyle" />
 
     <style name="GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle" parent="Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle" />
+
+    <style name="GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle" parent="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle" />
+
+    <style name="GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle" parent="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle" />
 
     <style name="GiniCaptureTheme.Camera.DocumentImportSubtitle.TextStyle" parent="Root.GiniCaptureTheme.Camera.DocumentImportSubtitle.TextStyle" />
 

--- a/ginicapture/src/main/res/values/styles.xml
+++ b/ginicapture/src/main/res/values/styles.xml
@@ -71,13 +71,13 @@
         <item name="gcCustomFont" />
     </style>
 
-    <style name="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle" parent="TextAppearance.AppCompat">
+    <style name="Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textSize">14sp</item>
         <item name="android:textColor">@color/gc_unsupported_qrcode_detected_popup_message_1</item>
         <item name="gcCustomFont" />
     </style>
 
-    <style name="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle" parent="TextAppearance.AppCompat">
+    <style name="Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle" parent="TextAppearance.AppCompat">
         <item name="android:textSize">14sp</item>
         <item name="android:textColor">@color/gc_unsupported_qrcode_detected_popup_message_2</item>
         <item name="gcCustomFont" />
@@ -266,9 +266,9 @@
 
     <style name="GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle" parent="Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.Message2.TextStyle" />
 
-    <style name="GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle" parent="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle" />
+    <style name="GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle" parent="Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage1.TextStyle" />
 
-    <style name="GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle" parent="Root.GiniVisionTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle" />
+    <style name="GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle" parent="Root.GiniCaptureTheme.Camera.QRCodeDetectedPopup.UnsupportedMessage2.TextStyle" />
 
     <style name="GiniCaptureTheme.Camera.DocumentImportSubtitle.TextStyle" parent="Root.GiniCaptureTheme.Camera.DocumentImportSubtitle.TextStyle" />
 


### PR DESCRIPTION
Please review after #4.

Ported feature from GVL by applying the following GVL commits:
* 320f2726 Don't show the QR code hint popup after importing a document
* c99536bc Fix QR code hint popup text layout issue
* c52e79e4 Prevent click handling of import button when disabled
* 0b6925b5 Update customization guide with QR code scanner hint customization
* c6b7b960 Add QR code scanner hint popup to the tablet layouts
* 36b44d63 Show a QR code scanner hint popup
* 2cb5cc5e Use the `HintPopup` to show/hide the upload (document import) popup
* 42b21119 Extract hint popup related logic into a dedicated class
* fae49c37 Hide upload hint popup on tap outside
* 4bb6118a Disable the flash button while the upload hint popup is shown
* 318691ea Show QR code as a supported format