### PR TITLE
Pia 1992 update to gradle7 publish plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,8 @@ pipeline {
         SCREEN_API_EXAMPLE_APP_KEYSTORE_PSW = credentials('gini-vision-library-android_screen-api-example-app-release-keystore-password')
         SCREEN_API_EXAMPLE_APP_KEY_PSW = credentials('gini-vision-library-android_screen-api-example-app-release-key-password')
         EXAMPLE_APP_CLIENT_CREDENTIALS = credentials('gini-vision-library-android_gini-api-client-credentials')
-        JAVA9 = '/Users/mobilecd/java-vm/jdk-9.0.4.jdk/Contents/Home'
+        JAVA8 = '/Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home'
+        JAVA11 = '/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home'
     }
     stages {
         stage('Import Pipeline Libraries') {
@@ -37,7 +38,8 @@ pipeline {
                     ./gradlew clean \
                     ginicapture:assembleDebug ginicapture:assembleRelease \
                     ginicapture-network:assembleDebug ginicapture-network:assembleRelease \
-                    ginicapture-accounting-network:assembleDebug ginicapture-accounting-network:assembleRelease
+                    ginicapture-accounting-network:assembleDebug ginicapture-accounting-network:assembleRelease \
+                    -Dorg.gradle.java.home=$JAVA11
                 '''
             }
         }
@@ -57,7 +59,7 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew ginicapture:testDebugUnitTest -Dorg.gradle.java.home=$JAVA9'
+                sh './gradlew ginicapture:testDebugUnitTest -Dorg.gradle.java.home=$JAVA9 -Dorg.gradle.java.home=$JAVA11'
             }
             post {
                 always {
@@ -82,7 +84,7 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew ginicapture:jacocoTestDebugUnitTestReport -Dorg.gradle.java.home=$JAVA9'
+                sh './gradlew ginicapture:jacocoTestDebugUnitTestReport -Dorg.gradle.java.home=$JAVA11'
                 publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'ginicapture/build/jacoco/jacocoHtml', reportFiles: 'index.html', reportName: 'Code Coverage Report', reportTitles: ''])
             }
         }
@@ -102,7 +104,7 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew generateJavadocCoverage'
+                sh './gradlew generateJavadocCoverage -Dorg.gradle.java.home=$JAVA8 -PandroidGradlePluginVersion="4.2.2"'
                 publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'ginicapture/build/reports/javadoc-coverage', reportFiles: 'index.html', reportName: 'Gini Capture Javadoc Coverage Report', reportTitles: ''])
                 publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'ginicapture-network/build/reports/javadoc-coverage', reportFiles: 'index.html', reportName: 'Gini Capture Network Javadoc Coverage Report', reportTitles: ''])
                 publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'ginicapture-accounting-network/build/reports/javadoc-coverage', reportFiles: 'index.html', reportName: 'Gini Capture Accounting Network Javadoc Coverage Report', reportTitles: ''])
@@ -124,9 +126,9 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew ginicapture:lint ginicapture:checkstyle ginicapture:pmd'
-                sh './gradlew ginicapture-network:lint ginicapture-network:checkstyle ginicapture-network:pmd'
-                sh './gradlew ginicapture-accounting-network:lint ginicapture-accounting-network:checkstyle ginicapture-accounting-network:pmd'
+                sh './gradlew ginicapture:lint ginicapture:checkstyle ginicapture:pmd -Dorg.gradle.java.home=$JAVA11'
+                sh './gradlew ginicapture-network:lint ginicapture-network:checkstyle ginicapture-network:pmd -Dorg.gradle.java.home=$JAVA11'
+                sh './gradlew ginicapture-accounting-network:lint ginicapture-accounting-network:checkstyle ginicapture-accounting-network:pmd -Dorg.gradle.java.home=$JAVA11'
                 androidLint canComputeNew: false, defaultEncoding: '', healthy: '', pattern: 'ginicapture/build/reports/lint-results.xml', unHealthy: ''
                 androidLint canComputeNew: false, defaultEncoding: '', healthy: '', pattern: 'ginicapture-network/build/reports/lint-results.xml', unHealthy: ''
                 androidLint canComputeNew: false, defaultEncoding: '', healthy: '', pattern: 'ginicapture-accounting-network/build/reports/lint-results.xml', unHealthy: ''
@@ -176,7 +178,7 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew ginicapture:dokkaHtml ginicapture-network:generateJavadoc ginicapture-accounting-network:generateJavadoc'
+                sh './gradlew ginicapture:dokkaHtml ginicapture-network:generateJavadoc ginicapture-accounting-network:generateJavadoc -Dorg.gradle.java.home=$JAVA8 -PandroidGradlePluginVersion="4.2.2"'
                 publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'ginicapture/build/dokka/ginicapture', reportFiles: 'index.html', reportName: 'Gini Capture KDoc', reportTitles: ''])
                 publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'ginicapture-network/build/docs/javadoc', reportFiles: 'index.html', reportName: 'Gini Capture Network Javadoc', reportTitles: ''])
                 publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'ginicapture-accounting-network/build/docs/javadoc', reportFiles: 'index.html', reportName: 'Gini Capture Accounting Network Javadoc', reportTitles: ''])
@@ -219,9 +221,27 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew screenapiexample::clean screenapiexample::assembleRelease -PreleaseKeystoreFile=screen_api_example.jks -PreleaseKeystorePassword="$SCREEN_API_EXAMPLE_APP_KEYSTORE_PSW" -PreleaseKeyAlias=screen_api_example -PreleaseKeyPassword="$SCREEN_API_EXAMPLE_APP_KEY_PSW" -PclientId=$EXAMPLE_APP_CLIENT_CREDENTIALS_USR -PclientSecret=$EXAMPLE_APP_CLIENT_CREDENTIALS_PSW'
-                sh './gradlew componentapiexample::clean componentapiexample::assembleRelease -PreleaseKeystoreFile=component_api_example.jks -PreleaseKeystorePassword="$COMPONENT_API_EXAMPLE_APP_KEYSTORE_PSW" -PreleaseKeyAlias=component_api_example -PreleaseKeyPassword="$COMPONENT_API_EXAMPLE_APP_KEY_PSW" -PclientId=$EXAMPLE_APP_CLIENT_CREDENTIALS_USR -PclientSecret=$EXAMPLE_APP_CLIENT_CREDENTIALS_PSW'
-                archiveArtifacts 'screenapiexample/build/outputs/apk/release/screenapiexample-release.apk,componentapiexample/build/outputs/apk/release/componentapiexample-release.apk,screenapiexample/build/outputs/mapping/release/mapping.txt,componentapiexample/build/outputs/mapping/release/mapping.txt'
+                sh '''
+                    ./gradlew screenapiexample::clean screenapiexample::assembleRelease \
+                    -PreleaseKeystoreFile=screen_api_example.jks -PreleaseKeystorePassword="$SCREEN_API_EXAMPLE_APP_KEYSTORE_PSW" \
+                    -PreleaseKeyAlias=screen_api_example -PreleaseKeyPassword="$SCREEN_API_EXAMPLE_APP_KEY_PSW" \
+                    -PclientId=$EXAMPLE_APP_CLIENT_CREDENTIALS_USR -PclientSecret=$EXAMPLE_APP_CLIENT_CREDENTIALS_PSW \
+                    -Dorg.gradle.java.home=$JAVA11
+                '''
+                sh '''
+                    ./gradlew componentapiexample::clean componentapiexample::assembleRelease \
+                    -PreleaseKeystoreFile=component_api_example.jks -PreleaseKeystorePassword="$COMPONENT_API_EXAMPLE_APP_KEYSTORE_PSW" \
+                    -PreleaseKeyAlias=component_api_example -PreleaseKeyPassword="$COMPONENT_API_EXAMPLE_APP_KEY_PSW" \
+                    -PclientId=$EXAMPLE_APP_CLIENT_CREDENTIALS_USR -PclientSecret=$EXAMPLE_APP_CLIENT_CREDENTIALS_PSW \
+                    -Dorg.gradle.java.home=$JAVA11
+                '''
+                archiveArtifacts '''
+                    screenapiexample/build/outputs/apk/release/screenapiexample-release.apk,\
+                    componentapiexample/build/outputs/apk/release/componentapiexample-release.apk,\
+                    screenapiexample/build/outputs/mapping/release/mapping.txt,\
+                    componentapiexample/build/outputs/mapping/release/mapping.txt \
+                    -Dorg.gradle.java.home=$JAVA11
+                '''
             }
         }
         stage('Release Documentation') {
@@ -259,7 +279,8 @@ pipeline {
                     ginicapture-accounting-network:uploadArchives \
                     -PmavenSnapshotsRepoUrl=https://repo.gini.net/nexus/content/repositories/snapshots \
                     -PrepoUser=$NEXUS_MAVEN_USR \
-                    -PrepoPassword=$NEXUS_MAVEN_PSW
+                    -PrepoPassword=$NEXUS_MAVEN_PSW \
+                    -Dorg.gradle.java.home=$JAVA11
                 '''
             }
         }
@@ -284,12 +305,11 @@ pipeline {
             }
             steps {
                 sh '''
-                    ./gradlew ginicapture:uploadArchives \
-                    ginicapture-network:uploadArchives \
-                    ginicapture-accounting-network:uploadArchives \
-                    -PmavenRepoUrl=https://repo.gini.net/nexus/content/repositories/open \
+                    ./gradlew publishReleasePublicationToOpenRepository \
+                    -PmavenOpenRepoUrl=https://repo.gini.net/nexus/content/repositories/open \
                     -PrepoUser=$NEXUS_MAVEN_USR \
-                    -PrepoPassword=$NEXUS_MAVEN_PSW
+                    -PrepoPassword=$NEXUS_MAVEN_PSW \
+                    -Dorg.gradle.java.home=$JAVA11
                 '''
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlinVersion = '1.5.20'
+    ext.kotlinVersion = '1.5.21'
     ext.dokkaVersion = '1.5.0'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath "com.android.tools.build:gradle:$androidGradlePluginVersion"
         classpath('com.hiya:jacoco-android:0.2')
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
         // For com.hiya:jacoco-android
         maven {
             url "https://plugins.gradle.org/m2/"
@@ -27,7 +26,6 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
         maven {
             // For Commons Imaging
             url 'https://repo.gini.net/nexus/content/repositories/open'

--- a/buildSrc/src/main/groovy/GenerateJavadoc.groovy
+++ b/buildSrc/src/main/groovy/GenerateJavadoc.groovy
@@ -1,8 +1,10 @@
 import org.gradle.api.Task
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.javadoc.Javadoc
 
 class GenerateJavadoc extends Javadoc {
 
+    @Input
     String projectTitle = "Unknown Title"
 
     @Override

--- a/componentapiexample/build.gradle
+++ b/componentapiexample/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     }
 
     // For backward compatibility
-    implementation('net.gini:gini-pay-api-lib-android:1.0.0-beta05@aar') {
+    implementation('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
         transitive = true
     }
 

--- a/exampleShared/build.gradle
+++ b/exampleShared/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation 'com.karumi:dexter:6.2.3'
 
     // For backward compatibility
-    implementation('net.gini:gini-pay-api-lib-android:1.0.0-beta05@aar') {
+    implementation('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
         transitive = true
     }
 

--- a/ginicapture-accounting-network/build.gradle
+++ b/ginicapture-accounting-network/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'com.android.library'
+plugins {
+    id 'com.android.library'
+    id 'maven-publish'
+}
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -52,7 +55,6 @@ dependencies {
 }
 
 apply from: rootProject.file('gradle/codequality.gradle')
-apply from: rootProject.file('gradle/maven.gradle')
 apply from: rootProject.file('gradle/javadoc_coverage.gradle')
 
 task generateJavadoc(type: GenerateJavadoc) {
@@ -71,7 +73,4 @@ task javadocJar(type: Jar, dependsOn: generateJavadoc) {
     from destinationDir
 }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-}
+apply from: rootProject.file('gradle/maven.gradle')

--- a/ginicapture-accounting-network/build.gradle
+++ b/ginicapture-accounting-network/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "androidx.annotation:annotation:$versions.androidxAnnotations"
     implementation project(path: ':ginicapture')
-    api('net.gini:gini-pay-api-lib-android:1.0.0-beta05@aar') {
+    api('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
         transitive = true
     }
 

--- a/ginicapture-accounting-network/gradle.properties
+++ b/ginicapture-accounting-network/gradle.properties
@@ -1,3 +1,4 @@
+groupId=net.gini
 artifactId=gini-capture-accounting-network-lib
 android.useAndroidX=true
 android.enableJetifier=true

--- a/ginicapture-network/build.gradle
+++ b/ginicapture-network/build.gradle
@@ -1,4 +1,7 @@
-apply plugin: 'com.android.library'
+plugins {
+    id 'com.android.library'
+    id 'maven-publish'
+}
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
@@ -52,7 +55,6 @@ dependencies {
 }
 
 apply from: rootProject.file('gradle/codequality.gradle')
-apply from: rootProject.file('gradle/maven.gradle')
 apply from: rootProject.file('gradle/javadoc_coverage.gradle')
 
 task generateJavadoc(type: GenerateJavadoc) {
@@ -71,7 +73,4 @@ task javadocJar(type: Jar, dependsOn: generateJavadoc) {
     from destinationDir
 }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-}
+apply from: rootProject.file('gradle/maven.gradle')

--- a/ginicapture-network/build.gradle
+++ b/ginicapture-network/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "androidx.annotation:annotation:$versions.androidxAnnotations"
     implementation project(path: ':ginicapture')
-    api('net.gini:gini-pay-api-lib-android:1.0.0-beta05@aar') {
+    api('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
         transitive = true
     }
 

--- a/ginicapture-network/gradle.properties
+++ b/ginicapture-network/gradle.properties
@@ -1,3 +1,4 @@
+groupId=net.gini
 artifactId=gini-capture-network-lib
 android.useAndroidX=true
 android.enableJetifier=true

--- a/ginicapture/build.gradle
+++ b/ginicapture/build.gradle
@@ -1,7 +1,11 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'com.hiya.jacoco-android'
-apply plugin: 'org.jetbrains.dokka'
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'com.hiya.jacoco-android'
+    id 'org.jetbrains.dokka'
+    id 'maven-publish'
+}
+
 
 jacoco {
     toolVersion = "0.8.7"
@@ -124,7 +128,6 @@ dependencies {
 }
 
 apply from: rootProject.file('gradle/codequality.gradle')
-apply from: rootProject.file('gradle/maven.gradle')
 apply from: rootProject.file('gradle/javadoc_coverage.gradle')
 apply from: rootProject.file('gradle/multidex_for_tests.gradle')
 
@@ -184,7 +187,4 @@ task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
     from dokkaJavadoc.outputDirectory
 }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-}
+apply from: rootProject.file('gradle/maven.gradle')

--- a/ginicapture/src/doc/source/index.rst
+++ b/ginicapture/src/doc/source/index.rst
@@ -18,7 +18,7 @@ Table of contents
 .. toctree::
     :maxdepth: 2
 
-    Gini Capture Javadoc <http://developer.gini.net/gini-capture-sdk-android/ginicapture/index.html>
+    Gini Capture Javadoc <http://developer.gini.net/gini-capture-sdk-android/ginicapture/dokka/index.html>
     Network Library Javadoc <http://developer.gini.net/gini-capture-sdk-android/network/javadoc/index.html>
     Accounting Network Library Javadoc <http://developer.gini.net/gini-capture-sdk-android/accounting/network/javadoc/index.html>
     customization-guide

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,3 +25,6 @@ android.useAndroidX=true
 # mavenOpenRepoUrl=https://repo.i.gini.net/nexus/content/repositories/open
 groupId=net.gini
 version=1.2.0
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,3 +28,5 @@ version=1.2.0
 
 android.useAndroidX=true
 android.enableJetifier=true
+
+androidGradlePluginVersion=7.0.0

--- a/gradle/git_utils.gradle
+++ b/gradle/git_utils.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'org.ajoberstar:grgit:1.5.0'

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,71 +1,85 @@
-apply plugin: 'maven'
-
-// In order to upload to the repo, you can create a file ~/.gradle/gradle.properties with
-//
+// Publishing requires the following parameters (you can either pass them in as gradle parameters with -P<paramName>=...
+// or you can add them to a gradle.properties file (for ex. in your global ~/.gradle/gradle.properties file)):
 // repoUser=<your user name>
 // repoPassword=<your password>
-// mavenSnapshotsRepoUrl=<url for snapshots>
-// mavenRepoUrl=<url for releases>
-// mavenLocalRepoUrl=<url for local releases>
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            pom.groupId = groupId
-            pom.artifactId = artifactId
-            pom.version = version
-            if (project.hasProperty('devVersionSuffix')) {
-                pom.version = "${pom.version}.${devVersionSuffix}"
-            }
-            if (project.hasProperty('mavenSnapshotsRepoUrl')) {
-                pom.version = "${pom.version}-SNAPSHOT"
-            }
+//
+// Also at least one of the following parameters are required:
+// mavenOpenRepoUrl=<URL>
+// mavenSnapshotsRepoUrl=<URL>
+// mavenLocalRepoUrl=<URL>
 
-            pom.project {
-                licenses {
-                    license {
-                        name 'Private License'
-                        url 'https://raw.githubusercontent.com/gini/gini-capture-sdk-android/master/LICENSE.md'
-                        distribution 'repo'
+// Because the components are created only during the afterEvaluate phase, we must
+// configure our publications using the afterEvaluate() lifecycle method
+afterEvaluate {
+
+    // Create source and javadoc artifacts
+    def sourcesArtifact = artifacts.add('archives', sourcesJar)
+    def javadocArtifact = artifacts.add('archives', javadocJar)
+
+    publishing {
+        publications {
+            // Creates a Maven publication called "release"
+            release(MavenPublication) {
+                // Applies the component for the release build variant
+                from components.release
+
+                // Adds additional artifacts
+                artifact sourcesArtifact
+                artifact javadocArtifact
+
+                // Customizes attributes of the publication
+                groupId = project.groupId
+                artifactId = project.artifactId
+                version = project.version
+
+                if (project.hasProperty('devVersionSuffix')) {
+                    version = "${version}.${devVersionSuffix}"
+                }
+                if (project.hasProperty('mavenSnapshotsRepoUrl')) {
+                    version = "${version}-SNAPSHOT"
+                }
+
+                pom {
+                    licenses {
+                        license {
+                            name = 'Private License'
+                            url = 'https://raw.githubusercontent.com/gini/gini-capture-sdk-android/master/LICENSE.md'
+                            distribution = 'repo'
+                        }
+                    }
+                    organization {
+                        name = 'Gini GmbH'
+                        url = 'https://www.gini.net/'
                     }
                 }
-                organization {
-                    name 'Gini GmbH'
-                    url 'https://www.gini.net/'
-                }
             }
+        }
 
-            pom.whenConfigured { pom ->
-                pom.dependencies.forEach { dep ->
-                    if (dep.getArtifactId().startsWith("gini-")) {
-                        dep.setGroupId(groupId)
+        repositories {
+            if (project.hasProperty('mavenOpenRepoUrl')) {
+                maven {
+                    name = "open"
+                    url = mavenOpenRepoUrl
+                    credentials {
+                        username = project.hasProperty('repoUser') ? repoUser : 'invalidUserName'
+                        password = project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
                     }
                 }
             }
-
             if (project.hasProperty('mavenSnapshotsRepoUrl')) {
-                repository(url: mavenSnapshotsRepoUrl) {
-                    authentication(
-                            userName: project.hasProperty('repoUser') ? repoUser : "invalidUserName",
-                            password: project.hasProperty('repoPassword') ? repoPassword : "invalidPassword"
-                    )
+                maven {
+                    name = "snapshots"
+                    url = mavenSnapshotsRepoUrl
+                    credentials {
+                        username = project.hasProperty('repoUser') ? repoUser : 'invalidUserName'
+                        password = project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
+                    }
                 }
             }
-
-            if (project.hasProperty('mavenRepoUrl')) {
-                repository(url: mavenRepoUrl) {
-                    authentication(
-                            userName: project.hasProperty('repoUser') ? repoUser : 'invalidUserName',
-                            password: project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
-                    )
-                }
-            }
-
             if (project.hasProperty('mavenLocalRepoUrl')) {
-                repository(url: mavenLocalRepoUrl) {
-                    authentication(
-                            userName: project.hasProperty('repoUser') ? repoUser : 'invalidUserName',
-                            password: project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
-                    )
+                maven {
+                    name = "local"
+                    url = mavenLocalRepoUrl
                 }
             }
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip

--- a/screenapiexample/build.gradle
+++ b/screenapiexample/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     }
 
     // For backward compatibility
-    implementation('net.gini:gini-pay-api-lib-android:1.0.0-beta05@aar') {
+    implementation('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
         transitive = true
     }
 

--- a/scripts/release-javadoc.sh
+++ b/scripts/release-javadoc.sh
@@ -22,12 +22,13 @@ git_password=$2
 rm -rf gh-pages
 git clone -b gh-pages https://"$git_user":"$git_password"@github.com/gini/gini-capture-sdk-android.git gh-pages
 
-rm -rf gh-pages/ginicapture
+rm -rf gh-pages/ginicapture/dokka
 rm -rf gh-pages/network/javadoc
 rm -rf gh-pages/accounting/network/javadoc
+mkdir -p gh-pages/ginicapture
 mkdir -p gh-pages/network
 mkdir -p gh-pages/accounting/network
-cp -a ginicapture/build/dokka/ gh-pages
+cp -a ginicapture/build/dokka gh-pages/ginicapture/
 cp -a ginicapture-network/build/docs/javadoc gh-pages/network/
 cp -a ginicapture-accounting-network/build/docs/javadoc gh-pages/accounting/network/
 cd gh-pages


### PR DESCRIPTION
Please review after #16.

Migrate to gradle 7 and replace the old maven plugin with the new `maven-publish` plugin for publishing releases to our own maven repository.

Also update the Android Gradle Plugin to the latest version (7.0.0) and use the required Java 11 to run gradle.

For creating javadoc we use AGP 4.2.2 and Java 8. With Java 11 (which is required for AGP 7.0.0) the Javadoc plugin of Gradle is broken and no javadoc is created.

### Ticket 
https://ginis.atlassian.net/browse/PIA-1192
