### PR TITLE
Release version 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ app/build.gradle:
 
 ```
 dependencies {
-    implementation 'net.gini:gini-capture-sdk:1.2.1'
+    implementation 'net.gini:gini-capture-sdk:1.3.0'
 }
 ```
 

--- a/ginicapture-accounting-network/README.md
+++ b/ginicapture-accounting-network/README.md
@@ -50,8 +50,8 @@ app/build.gradle:
 
 ```
 dependencies {
-    implementation 'net.gini:gini-capture-sdk:1.2.1'
-    implementation 'net.gini:gini-capture-accounting-network-lib:1.2.1'
+    implementation 'net.gini:gini-capture-sdk:1.3.0'
+    implementation 'net.gini:gini-capture-accounting-network-lib:1.3.0'
 }
 ```
 

--- a/ginicapture-network/README.md
+++ b/ginicapture-network/README.md
@@ -48,8 +48,8 @@ app/build.gradle:
 
 ```
 dependencies {
-    implementation 'net.gini:gini-capture-sdk:1.2.1'
-    implementation 'net.gini:gini-capture-network-lib:1.2.1'
+    implementation 'net.gini:gini-capture-sdk:1.3.0'
+    implementation 'net.gini:gini-capture-network-lib:1.3.0'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,7 @@ android.useAndroidX=true
 # mavenReleasesRepoUrl=https://repo.i.gini.net/nexus/content/repositories/releases
 # mavenOpenRepoUrl=https://repo.i.gini.net/nexus/content/repositories/open
 groupId=net.gini
-version=1.2.1
+version=1.3.0
 
 android.useAndroidX=true
 android.enableJetifier=true


### PR DESCRIPTION
The previous 1.2.1 release was a mistake and was cancelled. 

We already merged CameraX so we need to release version 1.3.0 instead:
* Uses the new CameraX API to control the camera.
* Increases minimum sdk version to 21.
* Updates the Gini Pay API Library to version [1.0.0](https://github.com/gini/gini-pay-api-lib-android/releases/tag/1.0.0) in the default networking implementations (`gini-capture-network-lib` and `gini-capture-accounting-network-lib`).