### PR TITLE
Target sdk version 31 (Android 12) and set `android:exported` attribute

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,9 @@ task printLibraryVersion {
 }
 
 ext {
-    compileSdkVersion = 30
+    compileSdkVersion = 31
     minSdkVersion = 21
-    targetSdkVersion = 30
+    targetSdkVersion = 31
     versionCode = libVersionCode
     versionName = libVersionName
 }

--- a/componentapiexample/src/main/AndroidManifest.xml
+++ b/componentapiexample/src/main/AndroidManifest.xml
@@ -39,7 +39,8 @@
         android:largeHeap="true">
         <activity
             android:name="net.gini.android.capture.component.MainActivity"
-            android:theme="@style/AppThemeCompat">
+            android:theme="@style/AppThemeCompat"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/screenapiexample/src/main/AndroidManifest.xml
+++ b/screenapiexample/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
         android:label="@string/app_name"
         android:largeHeap="true"
         android:theme="@style/AppTheme">
-        <activity android:name="net.gini.android.capture.screen.MainActivity">
+        <activity android:name="net.gini.android.capture.screen.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
When targeting Android 12 activities with intent filters require
the `android:exported` attribute:
https://developer.android.com/about/versions/12/behavior-changes-12#exported

### Ticket 
https://ginis.atlassian.net/browse/PIA-1598
