### PR TITLE
Feature/pia 1742 update pay api lib

### DIFF
--- a/componentapiexample/build.gradle
+++ b/componentapiexample/build.gradle
@@ -80,11 +80,6 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
 
-    // For backward compatibility
-    implementation('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
-        transitive = true
-    }
-
     // For testing the local version
     implementation project(path: ':ginicapture-network')
     // For testing a released version

--- a/exampleShared/build.gradle
+++ b/exampleShared/build.gradle
@@ -51,11 +51,6 @@ dependencies {
 
     implementation 'com.karumi:dexter:6.2.3'
 
-    // For backward compatibility
-    implementation('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
-        transitive = true
-    }
-
     // For testing the local version
     implementation project(path: ':ginicapture-network')
     // For testing a released version

--- a/ginicapture-accounting-network/build.gradle
+++ b/ginicapture-accounting-network/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "androidx.annotation:annotation:$versions.androidxAnnotations"
     implementation project(path: ':ginicapture')
-    api('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
+    api('net.gini:gini-pay-api-lib-android:1.0.1@aar') {
         transitive = true
     }
 

--- a/ginicapture-network/build.gradle
+++ b/ginicapture-network/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "androidx.annotation:annotation:$versions.androidxAnnotations"
     implementation project(path: ':ginicapture')
-    api('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
+    api('net.gini:gini-pay-api-lib-android:1.0.1@aar') {
         transitive = true
     }
 

--- a/screenapiexample/build.gradle
+++ b/screenapiexample/build.gradle
@@ -83,11 +83,6 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
 
-    // For backward compatibility
-    implementation('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
-        transitive = true
-    }
-
     // For testing the local version
     implementation project(path: ':ginicapture-network')
     // For testing a released version


### PR DESCRIPTION
Updates the Gini Pay API Library to 1.0.1 and removes superfluous dependency declarations in the example apps.

### How to test
Run the example apps, scan some documents and send feedback.

### Ticket 
https://ginis.atlassian.net/browse/PIA-1742
