### PR TITLE
Use `Activity.getDisplay()` only on Android 11 and newer

### DIFF
--- a/ginicapture/src/main/java/net/gini/android/capture/internal/camera/api/camerax/CameraXController.kt
+++ b/ginicapture/src/main/java/net/gini/android/capture/internal/camera/api/camerax/CameraXController.kt
@@ -81,7 +81,11 @@ internal class CameraXController(val activity: Activity) : CameraInterface {
                     return@addListener
                 }
 
-                val targetRotation = activity.display?.rotation ?: Surface.ROTATION_0
+                val targetRotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    activity.display?.rotation ?: Surface.ROTATION_0
+                } else {
+                    activity.windowManager.defaultDisplay.rotation
+                }
                 val isPortrait = ContextHelper.isPortraitOrientation(activity)
                 
                 // We require an image between 8MP and 12MP with at least 4:3 ratio


### PR DESCRIPTION
We replaced a deprecated method and should have also verified that it works on Android 5 and Android 6, too. It worked on Android 7 and newer and we overlooked the possibility of it not working on older versions...

### How to test
Run the example apps on emulators or devices running Android 6 and Android 5.
