### PR TITLE
Release version 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ app/build.gradle:
 
 ```
 dependencies {
-    implementation 'net.gini:gini-capture-sdk:1.3.0'
+    implementation 'net.gini:gini-capture-sdk:1.3.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,9 @@ task printLibraryVersion {
 }
 
 ext {
-    compileSdkVersion = 30
+    compileSdkVersion = 31
     minSdkVersion = 21
-    targetSdkVersion = 30
+    targetSdkVersion = 31
     versionCode = libVersionCode
     versionName = libVersionName
 }

--- a/componentapiexample/build.gradle
+++ b/componentapiexample/build.gradle
@@ -80,11 +80,6 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
 
-    // For backward compatibility
-    implementation('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
-        transitive = true
-    }
-
     // For testing the local version
     implementation project(path: ':ginicapture-network')
     // For testing a released version

--- a/componentapiexample/src/main/AndroidManifest.xml
+++ b/componentapiexample/src/main/AndroidManifest.xml
@@ -39,7 +39,8 @@
         android:largeHeap="true">
         <activity
             android:name="net.gini.android.capture.component.MainActivity"
-            android:theme="@style/AppThemeCompat">
+            android:theme="@style/AppThemeCompat"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/exampleShared/build.gradle
+++ b/exampleShared/build.gradle
@@ -51,11 +51,6 @@ dependencies {
 
     implementation 'com.karumi:dexter:6.2.3'
 
-    // For backward compatibility
-    implementation('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
-        transitive = true
-    }
-
     // For testing the local version
     implementation project(path: ':ginicapture-network')
     // For testing a released version

--- a/ginicapture-accounting-network/README.md
+++ b/ginicapture-accounting-network/README.md
@@ -50,8 +50,8 @@ app/build.gradle:
 
 ```
 dependencies {
-    implementation 'net.gini:gini-capture-sdk:1.3.0'
-    implementation 'net.gini:gini-capture-accounting-network-lib:1.3.0'
+    implementation 'net.gini:gini-capture-sdk:1.3.1
+    implementation 'net.gini:gini-capture-accounting-network-lib:1.3.1'
 }
 ```
 

--- a/ginicapture-accounting-network/build.gradle
+++ b/ginicapture-accounting-network/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "androidx.annotation:annotation:$versions.androidxAnnotations"
     implementation project(path: ':ginicapture')
-    api('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
+    api('net.gini:gini-pay-api-lib-android:1.0.1@aar') {
         transitive = true
     }
 

--- a/ginicapture-network/README.md
+++ b/ginicapture-network/README.md
@@ -48,8 +48,8 @@ app/build.gradle:
 
 ```
 dependencies {
-    implementation 'net.gini:gini-capture-sdk:1.3.0'
-    implementation 'net.gini:gini-capture-network-lib:1.3.0'
+    implementation 'net.gini:gini-capture-sdk:1.3.1'
+    implementation 'net.gini:gini-capture-network-lib:1.3.1'
 }
 ```
 

--- a/ginicapture-network/build.gradle
+++ b/ginicapture-network/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "androidx.annotation:annotation:$versions.androidxAnnotations"
     implementation project(path: ':ginicapture')
-    api('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
+    api('net.gini:gini-pay-api-lib-android:1.0.1@aar') {
         transitive = true
     }
 

--- a/ginicapture/src/main/java/net/gini/android/capture/internal/camera/api/camerax/CameraXController.kt
+++ b/ginicapture/src/main/java/net/gini/android/capture/internal/camera/api/camerax/CameraXController.kt
@@ -81,7 +81,11 @@ internal class CameraXController(val activity: Activity) : CameraInterface {
                     return@addListener
                 }
 
-                val targetRotation = activity.display?.rotation ?: Surface.ROTATION_0
+                val targetRotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    activity.display?.rotation ?: Surface.ROTATION_0
+                } else {
+                    activity.windowManager.defaultDisplay.rotation
+                }
                 val isPortrait = ContextHelper.isPortraitOrientation(activity)
                 
                 // We require an image between 8MP and 12MP with at least 4:3 ratio

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,6 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 #org.gradle.parallel=true
 
-android.useAndroidX=true
-
 # Set the desired repo urls in the build job
 # mavenSnapshotsRepoUrl=https://repo.i.gini.net/nexus/content/repositories/snapshots
 # mavenReleasesRepoUrl=https://repo.i.gini.net/nexus/content/repositories/releases

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
 # mavenReleasesRepoUrl=https://repo.i.gini.net/nexus/content/repositories/releases
 # mavenOpenRepoUrl=https://repo.i.gini.net/nexus/content/repositories/open
 groupId=net.gini
-version=1.3.0
+version=1.3.1
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/screenapiexample/build.gradle
+++ b/screenapiexample/build.gradle
@@ -83,11 +83,6 @@ dependencies {
         exclude group: 'com.google.android', module: 'android'
     }
 
-    // For backward compatibility
-    implementation('net.gini:gini-pay-api-lib-android:1.0.0@aar') {
-        transitive = true
-    }
-
     // For testing the local version
     implementation project(path: ':ginicapture-network')
     // For testing a released version

--- a/screenapiexample/src/main/AndroidManifest.xml
+++ b/screenapiexample/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
         android:label="@string/app_name"
         android:largeHeap="true"
         android:theme="@style/AppTheme">
-        <activity android:name="net.gini.android.capture.screen.MainActivity">
+        <activity android:name="net.gini.android.capture.screen.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
* Raises target sdk version to 31 (Android 12).
* Updates the Gini Pay API Library to version [1.0.1](https://github.com/gini/gini-pay-api-lib-android/releases/tag/1.0.1) in the default networking implementations (`gini-capture-network-lib` and `gini-capture-accounting-network-lib`).
* Fixes a CameraX related crash on Android 5 and Android 6.