### PR TITLE
Feature/pia 1763 default error tracking

### DIFF
--- a/exampleShared/build.gradle
+++ b/exampleShared/build.gradle
@@ -20,8 +20,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode appVersionCode
-        versionName appVersionName
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/ginicapture-accounting-network/build.gradle
+++ b/ginicapture-accounting-network/build.gradle
@@ -9,8 +9,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode rootProject.ext.versionCode
-        versionName rootProject.ext.versionName
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/ginicapture-network/build.gradle
+++ b/ginicapture-network/build.gradle
@@ -9,8 +9,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode rootProject.ext.versionCode
-        versionName rootProject.ext.versionName
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }

--- a/ginicapture-network/build.gradle
+++ b/ginicapture-network/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.library'
+    id 'kotlin-android'
     id 'maven-publish'
 }
 

--- a/ginicapture-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkApi.java
+++ b/ginicapture-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkApi.java
@@ -1,10 +1,16 @@
 package net.gini.android.capture.network;
 
+import static net.gini.android.capture.network.logging.UtilKt.errorLogFromException;
+import static net.gini.android.capture.network.logging.UtilKt.responseDetails;
+
 import androidx.annotation.NonNull;
+
+import com.android.volley.VolleyError;
 
 import net.gini.android.DocumentTaskManager;
 import net.gini.android.capture.GiniCapture;
 import net.gini.android.capture.internal.camera.api.UIExecutor;
+import net.gini.android.capture.logging.ErrorLog;
 import net.gini.android.capture.network.model.CompoundExtractionsMapper;
 import net.gini.android.capture.network.model.GiniCaptureCompoundExtraction;
 import net.gini.android.capture.network.model.GiniCaptureSpecificExtraction;
@@ -92,11 +98,21 @@ public class GiniCaptureDefaultNetworkApi implements GiniCaptureNetworkApi {
                             public void run() {
                                 if (task.isFaulted()) {
                                     LOG.error(
-                                            "Send feedback failed for api document {}: {}",
+                                            "Send feedback failed for api document {}",
                                             document.getId(), task.getError());
                                     String message = "unknown";
                                     if (task.getError() != null) {
                                         message = task.getError().getMessage();
+                                        if (task.getError() instanceof VolleyError) {
+                                            final VolleyError volleyError = (VolleyError) task.getError();
+                                            message = responseDetails(volleyError);
+                                            mDefaultNetworkService.handleErrorLog(
+                                                    errorLogFromException("Failed to send feedback for document " +
+                                                            document.getId(), task.getError()));
+                                        }
+                                    } else {
+                                        mDefaultNetworkService.handleErrorLog(new ErrorLog(
+                                                "Failed to send feedback for document " + document.getId(), null));
                                     }
                                     callback.failure(new Error(message));
                                 } else {
@@ -111,11 +127,15 @@ public class GiniCaptureDefaultNetworkApi implements GiniCaptureNetworkApi {
                 });
             } catch (final JSONException e) {
                 LOG.error("Send feedback failed for api document {}: {}", document.getId(), e);
+                mDefaultNetworkService.handleErrorLog(new ErrorLog(
+                        "Failed to send feedback for document " + document.getId(), e));
                 callback.failure(new Error(e.getMessage()));
             }
         } else {
-            LOG.error("Send feedback failed: no Gini Api Document available");
-            callback.failure(new Error("Feedback not set: no Gini Api Document available"));
+            LOG.error("Send feedback failed: no api document available");
+            mDefaultNetworkService.handleErrorLog(new ErrorLog(
+                    "Failed to send feedback: no api document available", null));
+            callback.failure(new Error("Feedback not set: no api document available"));
         }
     }
 

--- a/ginicapture-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
+++ b/ginicapture-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
@@ -311,6 +311,11 @@ public class GiniCaptureDefaultNetworkService implements GiniCaptureNetworkServi
     }
 
     @Override
+    public void handleErrorLog(@NonNull ErrorLog errorLog) {
+        LOG.error(errorLog.toString(), errorLog.getException());
+    }
+
+    @Override
     public void cleanup() {
         mAnalyzedGiniApiDocument = null; // NOPMD
         mGiniApiDocuments.clear();

--- a/ginicapture-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
+++ b/ginicapture-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
@@ -1,9 +1,13 @@
 package net.gini.android.capture.network;
 
+import static net.gini.android.capture.network.logging.UtilKt.errorLogFromException;
+import static net.gini.android.capture.network.logging.UtilKt.responseDetails;
+
 import android.content.Context;
 import android.text.TextUtils;
 
 import com.android.volley.Cache;
+import com.android.volley.VolleyError;
 
 import net.gini.android.DocumentMetadata;
 import net.gini.android.DocumentTaskManager;
@@ -12,6 +16,7 @@ import net.gini.android.GiniBuilder;
 import net.gini.android.authorization.CredentialsStore;
 import net.gini.android.authorization.SessionManager;
 import net.gini.android.authorization.SharedPreferencesCredentialsStore;
+import net.gini.android.capture.logging.ErrorLog;
 import net.gini.android.capture.network.model.CompoundExtractionsMapper;
 import net.gini.android.capture.network.model.GiniCaptureCompoundExtraction;
 import net.gini.android.capture.network.model.GiniCaptureReturnReason;
@@ -148,8 +153,14 @@ public class GiniCaptureDefaultNetworkService implements GiniCaptureNetworkServi
         if (!task.isFaulted()) {
             return "";
         }
-        final String errorMessage = task.getError().getMessage();
-        return errorMessage != null ? errorMessage : task.getError().toString();
+        String errorMessage = "unknown";
+        if (task.getError() != null) {
+            errorMessage = task.getError().getMessage();
+            if (task.getError() instanceof VolleyError) {
+                errorMessage = responseDetails((VolleyError) task.getError());
+            }
+        }
+        return errorMessage;
     }
 
 

--- a/ginicapture-network/src/main/java/net/gini/android/capture/network/logging/Util.kt
+++ b/ginicapture-network/src/main/java/net/gini/android/capture/network/logging/Util.kt
@@ -1,0 +1,24 @@
+package net.gini.android.capture.network.logging
+
+import com.android.volley.VolleyError
+import net.gini.android.capture.logging.ErrorLog
+import java.nio.charset.Charset
+
+
+fun <T : Exception> errorLogFromException(description: String, exception: T): ErrorLog =
+    if (exception is VolleyError) {
+        ErrorLog(
+            description = "$description\n${exception.responseDetails()}",
+            exception = exception
+        )
+    } else {
+        ErrorLog(description = description, exception = exception)
+    }
+
+fun VolleyError.responseDetails(): String =
+    this.networkResponse?.let { response ->
+        val statusCode = response.statusCode
+        val headers = response.allHeaders?.toList()?.joinToString("\n") { "${it.name}: ${it.value}" } ?: ""
+        val body = response.data?.let { String(it, Charset.forName("UTF-8")) } ?: ""
+        return "Status code: $statusCode\nHeaders:\n$headers\nBody:\n$body"
+    } ?: this.message ?: toString()

--- a/ginicapture/build.gradle
+++ b/ginicapture/build.gradle
@@ -17,8 +17,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode rootProject.ext.versionCode
-        versionName rootProject.ext.versionName
 
         // Use the test runner with JUnit4 support
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/ginicapture/src/main/java/net/gini/android/capture/analysis/AnalysisScreenPresenter.java
+++ b/ginicapture/src/main/java/net/gini/android/capture/analysis/AnalysisScreenPresenter.java
@@ -27,6 +27,8 @@ import net.gini.android.capture.internal.storage.ImageDiskStore;
 import net.gini.android.capture.internal.ui.ErrorSnackbar;
 import net.gini.android.capture.internal.util.FileImportHelper;
 import net.gini.android.capture.internal.util.MimeType;
+import net.gini.android.capture.logging.ErrorLog;
+import net.gini.android.capture.logging.ErrorLogger;
 import net.gini.android.capture.network.model.GiniCaptureCompoundExtraction;
 import net.gini.android.capture.network.model.GiniCaptureReturnReason;
 import net.gini.android.capture.network.model.GiniCaptureSpecificExtraction;
@@ -263,8 +265,8 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
         final Uri uri = pdfDocument.getUri();
         try {
             return UriHelper.getFilenameFromUri(uri, getActivity());
-        } catch (final IllegalStateException e) { // NOPMD
-            // Ignore
+        } catch (final IllegalStateException e) {
+            ErrorLogger.log(new ErrorLog("Failed to get pdf filename", e));
         }
         return null;
     }
@@ -385,6 +387,7 @@ class AnalysisScreenPresenter extends AnalysisScreenContract.Presenter {
                         if (isStopped()) {
                             return;
                         }
+                        ErrorLogger.log(new ErrorLog("Failed to load document data", exception));
                         getAnalysisFragmentListenerOrNoOp().onError(
                                 new GiniCaptureError(GiniCaptureError.ErrorCode.ANALYSIS,
                                         "An error occurred while loading the document."));

--- a/ginicapture/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
+++ b/ginicapture/src/main/java/net/gini/android/capture/camera/CameraFragmentImpl.java
@@ -72,6 +72,8 @@ import net.gini.android.capture.internal.util.DeviceHelper;
 import net.gini.android.capture.internal.util.FileImportValidator;
 import net.gini.android.capture.internal.util.MimeType;
 import net.gini.android.capture.internal.util.Size;
+import net.gini.android.capture.logging.ErrorLog;
+import net.gini.android.capture.logging.ErrorLogger;
 import net.gini.android.capture.network.model.GiniCaptureExtraction;
 import net.gini.android.capture.network.model.GiniCaptureSpecificExtraction;
 import net.gini.android.capture.tracking.CameraScreenEvent;
@@ -1842,22 +1844,15 @@ class CameraFragmentImpl implements CameraFragmentInterface, PaymentQRCodeReader
     private void handleError(final GiniCaptureError.ErrorCode errorCode,
             @NonNull final String message,
             @Nullable final Throwable throwable) {
+        ErrorLogger.log(new ErrorLog(errorCode.toString() + ": " + message, throwable));
         String errorMessage = message;
         if (throwable != null) {
             LOG.error(message, throwable);
             // Add error info to the message to help clients, if they don't have logging enabled
             errorMessage = errorMessage + ": " + throwable.getMessage();
+        } else {
+            LOG.error(message);
         }
-        handleError(errorCode, errorMessage);
-    }
-
-    private void handleError(final GiniCaptureError.ErrorCode errorCode,
-            @NonNull final String message) {
-        handleError(new GiniCaptureError(errorCode, message));
-    }
-
-    private void handleError(@NonNull final GiniCaptureError error) {
-        LOG.error(error.getMessage());
-        mListener.onError(error);
+        mListener.onError(new GiniCaptureError(errorCode, errorMessage));
     }
 }

--- a/ginicapture/src/main/java/net/gini/android/capture/internal/network/NetworkRequestsManager.java
+++ b/ginicapture/src/main/java/net/gini/android/capture/internal/network/NetworkRequestsManager.java
@@ -14,6 +14,8 @@ import net.gini.android.capture.document.GiniCaptureDocument;
 import net.gini.android.capture.document.GiniCaptureMultiPageDocument;
 import net.gini.android.capture.document.ImageDocument;
 import net.gini.android.capture.internal.cache.DocumentDataMemoryCache;
+import net.gini.android.capture.logging.ErrorLog;
+import net.gini.android.capture.logging.ErrorLogger;
 import net.gini.android.capture.network.AnalysisResult;
 import net.gini.android.capture.network.Error;
 import net.gini.android.capture.network.GiniCaptureNetworkCallback;
@@ -128,6 +130,8 @@ public class NetworkRequestsManager {
                                 if (throwable != null) {
                                     if (isCancellation(throwable)) {
                                         cancellationToken.cancel();
+                                    } else {
+                                        ErrorLogger.log(new ErrorLog("Document upload failed", throwable));
                                     }
                                     mDocumentUploadFutures.remove(document.getId());
                                 }
@@ -297,6 +301,8 @@ public class NetworkRequestsManager {
                         if (throwable != null) {
                             if (isCancellation(throwable)) {
                                 cancellationToken.cancel();
+                            } else {
+                                ErrorLogger.log(new ErrorLog("Document deletion failed", throwable));
                             }
                         } else if (requestResult != null) {
                             mDocumentUploadFutures.remove(document.getId());
@@ -411,6 +417,8 @@ public class NetworkRequestsManager {
                         if (throwable != null) {
                             if (isCancellation(throwable)) {
                                 cancellationToken.cancel();
+                            } else {
+                                ErrorLogger.log(new ErrorLog("Document analysis failed", throwable));
                             }
                             mDocumentAnalyzeFutures.remove(
                                     multiPageDocument.getId());

--- a/ginicapture/src/main/java/net/gini/android/capture/logging/ErrorLog.kt
+++ b/ginicapture/src/main/java/net/gini/android/capture/logging/ErrorLog.kt
@@ -1,0 +1,16 @@
+package net.gini.android.capture.logging
+
+import android.os.Build
+import net.gini.android.capture.BuildConfig
+
+/**
+ * Contains an error description along with useful metadata for logging.
+ */
+data class ErrorLog @JvmOverloads constructor(
+    val deviceModel: String = Build.MODEL,
+    val osName: String = "Android",
+    val osVersion: String = Build.VERSION.RELEASE,
+    val captureVersion: String = BuildConfig.VERSION_NAME,
+    val description: String,
+    val exception: Throwable?,
+)

--- a/ginicapture/src/main/java/net/gini/android/capture/logging/ErrorLogger.kt
+++ b/ginicapture/src/main/java/net/gini/android/capture/logging/ErrorLogger.kt
@@ -1,0 +1,31 @@
+package net.gini.android.capture.logging
+
+import net.gini.android.capture.GiniCapture
+
+/**
+ * Internal use only.
+ *
+ * @suppress
+ */
+internal class ErrorLogger(
+    private val isGiniLoggingOn: Boolean,
+    private val giniErrorLogger: ErrorLoggerListener?,
+    private val customErrorLogger: ErrorLoggerListener?
+) : ErrorLoggerListener {
+
+    override fun handleErrorLog(errorLog: ErrorLog) {
+        if (isGiniLoggingOn) {
+            giniErrorLogger?.handleErrorLog(errorLog)
+        }
+        customErrorLogger?.handleErrorLog(errorLog)
+    }
+
+    companion object {
+        @JvmStatic
+        fun log(errorLog: ErrorLog) {
+            if (GiniCapture.hasInstance()) {
+                GiniCapture.getInstance().internal().errorLogger.handleErrorLog(errorLog);
+            }
+        }
+    }
+}

--- a/ginicapture/src/main/java/net/gini/android/capture/logging/ErrorLoggerListener.kt
+++ b/ginicapture/src/main/java/net/gini/android/capture/logging/ErrorLoggerListener.kt
@@ -1,0 +1,13 @@
+package net.gini.android.capture.logging
+
+/**
+ * Implement this interface if you would like to log Gini Capture SDK errors.
+ */
+interface ErrorLoggerListener {
+    /**
+     * Called when an error occurred inside the Gini Capture SDK.
+     *
+     * @param errorLog error details and metadata for logging
+     */
+    fun handleErrorLog(errorLog: ErrorLog) { }
+}

--- a/ginicapture/src/main/java/net/gini/android/capture/network/GiniCaptureNetworkService.java
+++ b/ginicapture/src/main/java/net/gini/android/capture/network/GiniCaptureNetworkService.java
@@ -2,16 +2,18 @@ package net.gini.android.capture.network;
 
 import android.content.Context;
 
+import androidx.annotation.NonNull;
+
 import net.gini.android.capture.Document;
 import net.gini.android.capture.GiniCapture;
 import net.gini.android.capture.analysis.AnalysisFragmentListener;
 import net.gini.android.capture.camera.CameraFragmentListener;
+import net.gini.android.capture.logging.ErrorLog;
+import net.gini.android.capture.logging.ErrorLoggerListener;
 import net.gini.android.capture.review.ReviewFragmentListener;
 import net.gini.android.capture.util.CancellationToken;
 
 import java.util.LinkedHashMap;
-
-import androidx.annotation.NonNull;
 
 /**
  * Created by Alpar Szotyori on 29.01.2018.
@@ -39,7 +41,7 @@ import androidx.annotation.NonNull;
  * AnalysisFragmentListener} won't be invoked. Otherwise the Gini Capture SDK falls back to
  * invoking those methods.
  */
-public interface GiniCaptureNetworkService {
+public interface GiniCaptureNetworkService extends ErrorLoggerListener {
 
     /**
      * Called when a document needs to be uploaded to the Gini API.
@@ -91,4 +93,7 @@ public interface GiniCaptureNetworkService {
      */
     void cleanup();
 
+    @Override
+    default void handleErrorLog(@NonNull ErrorLog errorLog) {
+    }
 }

--- a/ginicapture/src/main/java/net/gini/android/capture/review/ReviewFragmentImpl.java
+++ b/ginicapture/src/main/java/net/gini/android/capture/review/ReviewFragmentImpl.java
@@ -1,5 +1,11 @@
 package net.gini.android.capture.review;
 
+import static net.gini.android.capture.GiniCaptureError.ErrorCode.MISSING_GINI_CAPTURE_INSTANCE;
+import static net.gini.android.capture.internal.network.NetworkRequestsManager.isCancellation;
+import static net.gini.android.capture.internal.util.ActivityHelper.forcePortraitOrientationOnPhones;
+import static net.gini.android.capture.internal.util.FileImportHelper.showAlertIfOpenWithDocumentAndAppIsDefault;
+import static net.gini.android.capture.tracking.EventTrackingHelper.trackReviewScreenEvent;
+
 import android.animation.ObjectAnimator;
 import android.animation.ValueAnimator;
 import android.app.Activity;
@@ -37,18 +43,14 @@ import net.gini.android.capture.internal.network.NetworkRequestResult;
 import net.gini.android.capture.internal.network.NetworkRequestsManager;
 import net.gini.android.capture.internal.ui.FragmentImplCallback;
 import net.gini.android.capture.internal.util.FileImportHelper;
+import net.gini.android.capture.logging.ErrorLog;
+import net.gini.android.capture.logging.ErrorLogger;
 import net.gini.android.capture.tracking.ReviewScreenEvent;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jersey.repackaged.jsr166e.CompletableFuture;
-
-import static net.gini.android.capture.GiniCaptureError.ErrorCode.MISSING_GINI_CAPTURE_INSTANCE;
-import static net.gini.android.capture.internal.network.NetworkRequestsManager.isCancellation;
-import static net.gini.android.capture.internal.util.ActivityHelper.forcePortraitOrientationOnPhones;
-import static net.gini.android.capture.internal.util.FileImportHelper.showAlertIfOpenWithDocumentAndAppIsDefault;
-import static net.gini.android.capture.tracking.EventTrackingHelper.trackReviewScreenEvent;
 
 /**
  * Internal use only.
@@ -199,6 +201,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
                         return;
                     }
                     hideActivityIndicatorAndEnableButtons();
+                    ErrorLogger.log(new ErrorLog("Failed to load document data", exception));
                     mListener.onError(new GiniCaptureError(GiniCaptureError.ErrorCode.REVIEW,
                             "An error occurred while loading the document."));
                 }
@@ -276,6 +279,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
                 @Override
                 public void onError(final Exception exception) {
                     LOG.error("Failed to load a Photo for the ImageDocument");
+                    ErrorLogger.log(new ErrorLog("Failed to load Photo for ImageDocument", exception));
                     photoCreationFailed();
                 }
 
@@ -297,6 +301,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
                         @Override
                         public void onError(final Exception exception) {
                             LOG.error("Failed to instantiate a Photo from the ImageDocument");
+                            ErrorLogger.log(new ErrorLog("Failed to instantiate a Photo from the ImageDocument", exception));
                             photoCreationFailed();
                         }
 
@@ -328,6 +333,7 @@ class ReviewFragmentImpl implements ReviewFragmentInterface {
                 @Override
                 public void onFailed() {
                     LOG.error("Failed to compress the Photo");
+                    ErrorLogger.log(new ErrorLog("Image compression failed", null));
                     if (mNextClicked || mStopped) {
                         return;
                     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,4 +27,4 @@ version=1.3.1
 android.useAndroidX=true
 android.enableJetifier=true
 
-androidGradlePluginVersion=7.0.0
+androidGradlePluginVersion=7.0.1

--- a/screenapiexample/src/main/java/net/gini/android/capture/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/capture/screen/MainActivity.java
@@ -29,6 +29,8 @@ import net.gini.android.capture.example.shared.RuntimePermissionHandler;
 import net.gini.android.capture.help.FileImportActivity;
 import net.gini.android.capture.help.HelpItem;
 import net.gini.android.capture.help.PhotoTipsActivity;
+import net.gini.android.capture.logging.ErrorLog;
+import net.gini.android.capture.logging.ErrorLoggerListener;
 import net.gini.android.capture.onboarding.DefaultPagesPhone;
 import net.gini.android.capture.onboarding.OnboardingPage;
 import net.gini.android.capture.requirements.GiniCaptureRequirements;
@@ -326,6 +328,7 @@ public class MainActivity extends AppCompatActivity {
         }
         builder.setFlashButtonEnabled(true);
         builder.setEventTracker(new GiniCaptureEventTracker());
+        builder.setCustomErrorLoggerListener(new CustomErrorLoggerListener());
 
         final List<HelpItem.Custom> customHelpItems = new ArrayList<>();
         customHelpItems.add(new HelpItem.Custom(R.string.custom_help_screen_title,
@@ -496,7 +499,7 @@ public class MainActivity extends AppCompatActivity {
         root.addAppender(logcatAppender);
     }
 
-    private class GiniCaptureEventTracker implements EventTracker {
+    private static class GiniCaptureEventTracker implements EventTracker {
 
         @Override
         public void onOnboardingScreenEvent(final Event<OnboardingScreenEvent> event) {
@@ -559,6 +562,14 @@ public class MainActivity extends AppCompatActivity {
                     LOG.info("Analysis cancelled");
                     break;
             }
+        }
+    }
+
+    private static class CustomErrorLoggerListener implements ErrorLoggerListener {
+
+        @Override
+        public void handleErrorLog(@NonNull ErrorLog errorLog) {
+            LOG.error("Custom error logger: {}", errorLog.toString());
         }
     }
 }

--- a/screenapiexample/src/main/java/net/gini/android/capture/screen/MainActivity.java
+++ b/screenapiexample/src/main/java/net/gini/android/capture/screen/MainActivity.java
@@ -329,6 +329,8 @@ public class MainActivity extends AppCompatActivity {
         builder.setFlashButtonEnabled(true);
         builder.setEventTracker(new GiniCaptureEventTracker());
         builder.setCustomErrorLoggerListener(new CustomErrorLoggerListener());
+        // Uncomment to disable sending errors to Gini
+//        builder.setGiniErrorLoggerIsOn(false);
 
         final List<HelpItem.Custom> customHelpItems = new ArrayList<>();
         customHelpItems.add(new HelpItem.Custom(R.string.custom_help_screen_title,


### PR DESCRIPTION
Added error logging capability.

Error description and metadata is transported via `ErrorLog`.

To handle error logging events the `ErrorLoggerListener` needs to be implemented.

The `ErrorLogger` forwards the errors to our internal default `ErrorLoggerListener` and to the optional client provided custom implementation.

Clients can disable our default error logger using `GiniCapture.newInstance().setGiniErrorLoggerIsOn(false)`. It's on by default.

Our default implementation is provided by the `ginicapture-network` module.

Only clients using `ginicapture-network` will send us error logs unless they turn it off.

The client's custom `ErrorLoggerListener` will be always called.

Improved existing error tracking by adding the network response details (status code, headers and body) from Volley to the error message.

### How to test
Run the example app in airplane mode and view the logcat or add breakpoints to verify that the error is logged.

### Ticket 
https://ginis.atlassian.net/browse/PIA-1763
