### PR TITLE
Feature/pia 1797 send errors to pay api

### DIFF
--- a/ginicapture-accounting-network/build.gradle
+++ b/ginicapture-accounting-network/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "androidx.annotation:annotation:$versions.androidxAnnotations"
     implementation project(path: ':ginicapture')
-    api('net.gini:gini-pay-api-lib-android:1.0.1@aar') {
+    api('net.gini:gini-pay-api-lib-android:1.0.2@aar') {
         transitive = true
     }
 

--- a/ginicapture-network/build.gradle
+++ b/ginicapture-network/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "androidx.annotation:annotation:$versions.androidxAnnotations"
     implementation project(path: ':ginicapture')
-    api('net.gini:gini-pay-api-lib-android:1.0.1@aar') {
+    api('net.gini:gini-pay-api-lib-android:1.0.2@aar') {
         transitive = true
     }
 

--- a/ginicapture-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkApi.java
+++ b/ginicapture-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkApi.java
@@ -1,7 +1,7 @@
 package net.gini.android.capture.network;
 
 import static net.gini.android.capture.network.logging.UtilKt.errorLogFromException;
-import static net.gini.android.capture.network.logging.UtilKt.responseDetails;
+import static net.gini.android.capture.network.logging.UtilKt.getResponseDetails;
 
 import androidx.annotation.NonNull;
 
@@ -105,7 +105,7 @@ public class GiniCaptureDefaultNetworkApi implements GiniCaptureNetworkApi {
                                         message = task.getError().getMessage();
                                         if (task.getError() instanceof VolleyError) {
                                             final VolleyError volleyError = (VolleyError) task.getError();
-                                            message = responseDetails(volleyError);
+                                            message = getResponseDetails(volleyError);
                                             mDefaultNetworkService.handleErrorLog(
                                                     errorLogFromException("Failed to send feedback for document " +
                                                             document.getId(), task.getError()));

--- a/ginicapture-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
+++ b/ginicapture-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
@@ -1,14 +1,19 @@
 package net.gini.android.capture.network;
 
-import static net.gini.android.capture.network.logging.UtilKt.errorLogFromException;
 import static net.gini.android.capture.network.logging.UtilKt.getResponseDetails;
+import static net.gini.android.capture.network.logging.UtilKt.toErrorEvent;
 
 import android.content.Context;
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.XmlRes;
+
 import com.android.volley.Cache;
 import com.android.volley.VolleyError;
 
+import net.gini.android.BuildConfig;
 import net.gini.android.DocumentMetadata;
 import net.gini.android.DocumentTaskManager;
 import net.gini.android.Gini;
@@ -16,19 +21,19 @@ import net.gini.android.GiniBuilder;
 import net.gini.android.authorization.CredentialsStore;
 import net.gini.android.authorization.SessionManager;
 import net.gini.android.authorization.SharedPreferencesCredentialsStore;
+import net.gini.android.capture.Document;
+import net.gini.android.capture.GiniCapture;
+import net.gini.android.capture.document.GiniCaptureMultiPageDocument;
 import net.gini.android.capture.logging.ErrorLog;
 import net.gini.android.capture.network.model.CompoundExtractionsMapper;
 import net.gini.android.capture.network.model.GiniCaptureCompoundExtraction;
 import net.gini.android.capture.network.model.GiniCaptureReturnReason;
-import net.gini.android.capture.network.model.ReturnReasonsMapper;
-import net.gini.android.models.ExtractionsContainer;
-import net.gini.android.capture.Document;
-import net.gini.android.capture.GiniCapture;
-import net.gini.android.capture.document.GiniCaptureMultiPageDocument;
 import net.gini.android.capture.network.model.GiniCaptureSpecificExtraction;
+import net.gini.android.capture.network.model.ReturnReasonsMapper;
 import net.gini.android.capture.network.model.SpecificExtractionMapper;
 import net.gini.android.capture.util.CancellationToken;
 import net.gini.android.capture.util.NoOpCancellationToken;
+import net.gini.android.models.ExtractionsContainer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,9 +46,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.XmlRes;
 import bolts.Continuation;
 import bolts.Task;
 
@@ -313,6 +315,7 @@ public class GiniCaptureDefaultNetworkService implements GiniCaptureNetworkServi
     @Override
     public void handleErrorLog(@NonNull ErrorLog errorLog) {
         LOG.error(errorLog.toString(), errorLog.getException());
+        mGiniApi.getDocumentTaskManager().logErrorEvent(toErrorEvent(errorLog));
     }
 
     @Override

--- a/ginicapture-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
+++ b/ginicapture-network/src/main/java/net/gini/android/capture/network/GiniCaptureDefaultNetworkService.java
@@ -1,7 +1,7 @@
 package net.gini.android.capture.network;
 
 import static net.gini.android.capture.network.logging.UtilKt.errorLogFromException;
-import static net.gini.android.capture.network.logging.UtilKt.responseDetails;
+import static net.gini.android.capture.network.logging.UtilKt.getResponseDetails;
 
 import android.content.Context;
 import android.text.TextUtils;
@@ -157,7 +157,7 @@ public class GiniCaptureDefaultNetworkService implements GiniCaptureNetworkServi
         if (task.getError() != null) {
             errorMessage = task.getError().getMessage();
             if (task.getError() instanceof VolleyError) {
-                errorMessage = responseDetails((VolleyError) task.getError());
+                errorMessage = getResponseDetails((VolleyError) task.getError());
             }
         }
         return errorMessage;

--- a/ginicapture-network/src/main/java/net/gini/android/capture/network/logging/Util.kt
+++ b/ginicapture-network/src/main/java/net/gini/android/capture/network/logging/Util.kt
@@ -1,7 +1,11 @@
 package net.gini.android.capture.network.logging
 
 import com.android.volley.VolleyError
+import net.gini.android.BuildConfig
 import net.gini.android.capture.logging.ErrorLog
+import net.gini.android.requests.ErrorEvent
+import java.io.PrintWriter
+import java.io.StringWriter
 import java.nio.charset.Charset
 
 
@@ -22,3 +26,23 @@ internal val VolleyError.responseDetails: String
         val body = response.data?.let { String(it, Charset.forName("UTF-8")) } ?: ""
         return "Status code: $statusCode\nHeaders:\n$headers\nBody:\n$body"
     } ?: this.message ?: toString()
+
+internal fun ErrorLog.toErrorEvent(): ErrorEvent =
+    ErrorEvent(
+        deviceModel,
+        osName,
+        osVersion,
+        captureVersion,
+        BuildConfig.VERSION_NAME,
+        description = exception?.let {
+            "$description; Exception: ${it.stackTraceString}"
+        } ?: description
+    )
+
+internal val Throwable.stackTraceString: String
+    get() {
+        return StringWriter().let { sw ->
+            printStackTrace(PrintWriter(sw))
+            sw.toString()
+        }
+    }

--- a/ginicapture-network/src/main/java/net/gini/android/capture/network/logging/Util.kt
+++ b/ginicapture-network/src/main/java/net/gini/android/capture/network/logging/Util.kt
@@ -5,18 +5,18 @@ import net.gini.android.capture.logging.ErrorLog
 import java.nio.charset.Charset
 
 
-fun <T : Exception> errorLogFromException(description: String, exception: T): ErrorLog =
+internal fun <T : Exception> errorLogFromException(description: String, exception: T): ErrorLog =
     if (exception is VolleyError) {
         ErrorLog(
-            description = "$description\n${exception.responseDetails()}",
-            exception = exception
+            description = description,
+            exception = RuntimeException(exception.responseDetails, exception)
         )
     } else {
         ErrorLog(description = description, exception = exception)
     }
 
-fun VolleyError.responseDetails(): String =
-    this.networkResponse?.let { response ->
+internal val VolleyError.responseDetails: String
+    get() = this.networkResponse?.let { response ->
         val statusCode = response.statusCode
         val headers = response.allHeaders?.toList()?.joinToString("\n") { "${it.name}: ${it.value}" } ?: ""
         val body = response.data?.let { String(it, Charset.forName("UTF-8")) } ?: ""

--- a/ginicapture/src/doc/source/features.rst
+++ b/ginicapture/src/doc/source/features.rst
@@ -473,3 +473,19 @@ Screen + Component        Analysis Screen           ``AnalysisScreenEvent.RETRY`
 The supported events are listed for each screen in a dedicated enum. You can view these enums in our `reference documentation
 <http://developer.gini.net/gini-capture-sdk-android/ginicapture/dokka/ginicapture/net.gini.android.capture.tracking/index.html>`_.
 
+Error Logging
+-------------
+
+The SDK logs errors to the Gini Pay API when the default networking implementation is used (see the `Default networking
+implementation <integration.html#default-implementation>`_ section).
+
+You can disable the default error logging by passing ``false`` to ``GiniCapture.Builder.setGiniErrorLoggerIsOn()``.
+
+If you would like to get informed of error logging events you can pass your implementation of the
+``ErrorLoggerListener`` interface to ``GiniCapture.Builder``:
+
+.. code-block:: java
+
+    GiniCapture.newInstance()
+        .setCustomErrorLoggerListener(new MyErrorLoggerListener())
+        .build();


### PR DESCRIPTION
Sends errors including exception stack trace to the Gini Pay API.

### How to test
An error can be induced by replacing this line in the `GiniCaptureDefaultNetworkService`:
```
mGiniApi.getDocumentTaskManager().createCompositeDocument(giniApiDocumentRotationMap, null)
```
with:
```
mGiniApi.getDocumentTaskManager().createCompositeDocument(Collections.emptyList(), null)
```
This will cause the composite document creation to return a failure response.

To see the logged error log into [Graylog](http://log.prod.gini.net/search?q=&rangetype=relative&relative=300) and use this search query: `_exists_:captureSdkVersion`.

### Ticket 
https://ginis.atlassian.net/browse/PIA-1797
