### PR TITLE
Bugfix/pia 1821 action bar text color

### DIFF
--- a/ginicapture/src/main/res/values/styles.xml
+++ b/ginicapture/src/main/res/values/styles.xml
@@ -4,7 +4,7 @@
         <item name="colorPrimary">@color/gc_action_bar</item>
         <item name="colorPrimaryDark">@color/gc_status_bar</item>
         <item name="colorAccent">@color/gc_accent</item>
-        <item name="actionBarStyle">@style/GiniCaptureTheme.ActionBar</item>
+        <item name="actionBarTheme">@style/GiniCaptureTheme.ThemeOverlay.ActionBar</item>
     </style>
 
     <style name="GiniCaptureTheme.Transparent">
@@ -14,13 +14,10 @@
         <item name="android:colorBackgroundCacheHint">@null</item>
     </style>
 
-    <style name="GiniCaptureTheme.ActionBar" parent="Widget.MaterialComponents.ActionBar.Solid">
-        <item name="titleTextStyle">@style/GiniCaptureTheme.ActionBar.TextStyle</item>
+    <style name="GiniCaptureTheme.ThemeOverlay.ActionBar" parent="ThemeOverlay.MaterialComponents.ActionBar">
+        <item name="android:textColorPrimary">@color/gc_action_bar_title</item>
+        <item name="colorOnPrimary">@color/gc_action_bar_title</item>
         <item name="homeAsUpIndicator">@drawable/gc_action_bar_back</item>
-    </style>
-
-    <style name="GiniCaptureTheme.ActionBar.TextStyle" parent="TextAppearance.AppCompat.Widget.ActionBar.Title">
-        <item name="android:textColor">@color/gc_action_bar_title</item>
     </style>
 
     <style name="GiniCaptureTheme.Chooser">


### PR DESCRIPTION
For some reason the action bar (navigation bar) title text color customization stopped working. I found an alternative using theme overlays which works.

### How to test
Uncomment and change the `gc_action_bar_title` color in the screen api example's [colors.xml](https://github.com/gini/gini-capture-sdk-android/blob/main/screenapiexample/src/main/res/values/colors.xml#L12) and run the capture sdk. The text color in the action bar should be updated.

### Ticket 
https://ginis.atlassian.net/browse/PIA-1821
