### PR TITLE
Fix button background color customization on photo tips and no results screens

### DIFF
--- a/ginicapture/src/main/res/layout-sw600dp-land/gc_activity_photo_tips.xml
+++ b/ginicapture/src/main/res/layout-sw600dp-land/gc_activity_photo_tips.xml
@@ -171,15 +171,13 @@
 
     <Button
         android:id="@+id/gc_button_photo_tips_camera"
+        style="@style/GiniCaptureTheme.Button"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/gc_photo_tips_bottom_button_height"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:layout_margin="@dimen/gc_photo_tips_bottom_button_margin"
-        android:background="@color/gc_accent"
         android:text="@string/gc_photo_tips_camera_button"
-        android:width="@dimen/gc_photo_tips_bottom_button_max_width"
-        android:textColor="@color/gc_photo_tips_button_text" />
-
+        android:width="@dimen/gc_photo_tips_bottom_button_max_width"/>
 
 </RelativeLayout>

--- a/ginicapture/src/main/res/layout-sw600dp-land/gc_activity_photo_tips_with_multipage.xml
+++ b/ginicapture/src/main/res/layout-sw600dp-land/gc_activity_photo_tips_with_multipage.xml
@@ -203,15 +203,13 @@
 
     <Button
         android:id="@+id/gc_button_photo_tips_camera"
+        style="@style/GiniCaptureTheme.Button"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/gc_photo_tips_bottom_button_height"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:layout_margin="@dimen/gc_photo_tips_bottom_button_margin"
-        android:background="@color/gc_accent"
         android:text="@string/gc_photo_tips_camera_button"
-        android:width="@dimen/gc_photo_tips_bottom_button_max_width"
-        android:textColor="@color/gc_photo_tips_button_text" />
-
+        android:width="@dimen/gc_photo_tips_bottom_button_max_width" />
 
 </RelativeLayout>

--- a/ginicapture/src/main/res/layout-sw600dp-land/gc_fragment_noresults.xml
+++ b/ginicapture/src/main/res/layout-sw600dp-land/gc_fragment_noresults.xml
@@ -191,15 +191,13 @@
 
     <Button
         android:id="@+id/gc_button_no_results_back"
+        style="@style/GiniCaptureTheme.Button"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/gc_noresults_bottom_button_height"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:layout_margin="@dimen/gc_noresults_bottom_button_margin"
-        android:background="@color/gc_noresults_button"
         android:text="@string/gc_noresults_back_button"
-        android:width="@dimen/gc_noresults_bottom_button_max_width"
-        android:textColor="@color/gc_noresults_button_text" />
-
+        android:width="@dimen/gc_noresults_bottom_button_max_width" />
 
 </RelativeLayout>

--- a/ginicapture/src/main/res/layout-sw600dp/gc_activity_photo_tips.xml
+++ b/ginicapture/src/main/res/layout-sw600dp/gc_activity_photo_tips.xml
@@ -146,14 +146,13 @@
 
     <Button
         android:id="@+id/gc_button_photo_tips_camera"
+        style="@style/GiniCaptureTheme.Button"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/gc_photo_tips_bottom_button_height"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:layout_margin="@dimen/gc_photo_tips_bottom_button_margin"
-        android:background="@color/gc_accent"
         android:text="@string/gc_photo_tips_camera_button"
-        android:width="@dimen/gc_photo_tips_bottom_button_max_width"
-        android:textColor="@color/gc_photo_tips_button_text" />
+        android:width="@dimen/gc_photo_tips_bottom_button_max_width"/>
 
 </RelativeLayout>

--- a/ginicapture/src/main/res/layout-sw600dp/gc_activity_photo_tips_with_multipage.xml
+++ b/ginicapture/src/main/res/layout-sw600dp/gc_activity_photo_tips_with_multipage.xml
@@ -173,14 +173,13 @@
 
     <Button
         android:id="@+id/gc_button_photo_tips_camera"
+        style="@style/GiniCaptureTheme.Button"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/gc_photo_tips_bottom_button_height"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:layout_margin="@dimen/gc_photo_tips_bottom_button_margin"
-        android:background="@color/gc_accent"
         android:text="@string/gc_photo_tips_camera_button"
-        android:width="@dimen/gc_photo_tips_bottom_button_max_width"
-        android:textColor="@color/gc_photo_tips_button_text" />
+        android:width="@dimen/gc_photo_tips_bottom_button_max_width" />
 
 </RelativeLayout>

--- a/ginicapture/src/main/res/layout-sw600dp/gc_fragment_noresults.xml
+++ b/ginicapture/src/main/res/layout-sw600dp/gc_fragment_noresults.xml
@@ -165,15 +165,14 @@
 
     <Button
         android:id="@+id/gc_button_no_results_back"
+        style="@style/GiniCaptureTheme.Button"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/gc_noresults_bottom_button_height"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:layout_margin="@dimen/gc_noresults_bottom_button_margin"
-        android:background="@color/gc_noresults_button"
         android:text="@string/gc_noresults_back_button"
-        android:width="@dimen/gc_noresults_bottom_button_max_width"
-        android:textColor="@color/gc_noresults_button_text" />
+        android:width="@dimen/gc_noresults_bottom_button_max_width" />
 
 
 </RelativeLayout>

--- a/ginicapture/src/main/res/layout/gc_activity_photo_tips.xml
+++ b/ginicapture/src/main/res/layout/gc_activity_photo_tips.xml
@@ -146,13 +146,11 @@
 
     <Button
         android:id="@+id/gc_button_photo_tips_camera"
+        style="@style/GiniCaptureTheme.Button"
         android:layout_width="match_parent"
         android:layout_height="@dimen/gc_photo_tips_bottom_button_height"
         android:layout_alignParentBottom="true"
         android:layout_margin="@dimen/gc_photo_tips_bottom_button_margin"
-        android:background="@color/gc_photo_tips_button"
-        android:text="@string/gc_photo_tips_camera_button"
-        android:textColor="@color/gc_photo_tips_button_text" />
-
+        android:text="@string/gc_photo_tips_camera_button" />
 
 </RelativeLayout>

--- a/ginicapture/src/main/res/layout/gc_activity_photo_tips_with_multipage.xml
+++ b/ginicapture/src/main/res/layout/gc_activity_photo_tips_with_multipage.xml
@@ -173,13 +173,11 @@
 
     <Button
         android:id="@+id/gc_button_photo_tips_camera"
+        style="@style/GiniCaptureTheme.Button"
         android:layout_width="match_parent"
         android:layout_height="@dimen/gc_photo_tips_bottom_button_height"
         android:layout_alignParentBottom="true"
         android:layout_margin="@dimen/gc_photo_tips_bottom_button_margin"
-        android:background="@color/gc_photo_tips_button"
-        android:text="@string/gc_photo_tips_camera_button"
-        android:textColor="@color/gc_photo_tips_button_text" />
-
+        android:text="@string/gc_photo_tips_camera_button"/>
 
 </RelativeLayout>

--- a/ginicapture/src/main/res/layout/gc_fragment_noresults.xml
+++ b/ginicapture/src/main/res/layout/gc_fragment_noresults.xml
@@ -165,13 +165,11 @@
 
     <Button
         android:id="@+id/gc_button_no_results_back"
+        style="@style/GiniCaptureTheme.Button"
         android:layout_width="match_parent"
         android:layout_height="@dimen/gc_noresults_bottom_button_height"
         android:layout_alignParentBottom="true"
         android:layout_margin="@dimen/gc_noresults_bottom_button_margin"
-        android:background="@color/gc_noresults_button"
-        android:text="@string/gc_noresults_back_button"
-        android:textColor="@color/gc_noresults_button_text" />
-
+        android:text="@string/gc_noresults_back_button" />
 
 </RelativeLayout>

--- a/ginicapture/src/main/res/values/styles.xml
+++ b/ginicapture/src/main/res/values/styles.xml
@@ -321,5 +321,17 @@
 
     <style name="GiniCaptureTheme.Review.MultiPage.PageIndicator.TextStyle" parent="Root.GiniCaptureTheme.Review.MultiPage.PageIndicator.TextStyle" />
 
+    <!-- Root widget styles -->
+
+    <style name="Root.GiniCaptureTheme.Button" parent="Widget.MaterialComponents.Button">
+        <item name="android:textColor">@color/gc_photo_tips_button_text</item>
+        <item name="backgroundTint">@color/gc_photo_tips_button</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+    </style>
+
+    <!-- Widget styles used in the layouts which are overridable for customization -->
+
+    <style name="GiniCaptureTheme.Button" parent="Root.GiniCaptureTheme.Button" />
 
 </resources>


### PR DESCRIPTION
Using a custom button style with `backgroundTint` to set the button
background color according to the material components documentation:
https://github.com/material-components/material-components-android/blob/master/docs/components/Button.md#container-attributes-2

### How to test
Add these custom colors to `screenapiexample/src/main/res/values/colors.xml` and run it:
```
<color name="gc_photo_tips_button_text">#f00</color>
<color name="gc_photo_tips_button">#0f0</color>
```

### Ticket 
https://ginis.atlassian.net/browse/PIA-1247
